### PR TITLE
docs(changelog): Generate changelog for v0.2.0

### DIFF
--- a/CHANGELOGS/v0.2.0-release.md
+++ b/CHANGELOGS/v0.2.0-release.md
@@ -1,0 +1,8 @@
+## Changelog for v0.2.0
+
+Update from v0.1.0 to v0.2.0
+
+Release timestamp: 2025-07-23
+
+- docs: add copyright and terms of service headers (#5) (by @AEnjoy in `c897a9d`) 
+- ci: add makefile and github actions for package publishing (#6) (by @AEnjoy in `61fd6cf`) 


### PR DESCRIPTION
## Changelog for v0.2.0

Update from v0.1.0 to v0.2.0

Release timestamp: 2025-07-23

- docs: add copyright and terms of service headers (#5) (by @AEnjoy in `c897a9d`) 
- ci: add makefile and github actions for package publishing (#6) (by @AEnjoy in `61fd6cf`)