### PR TITLE
fix: content-type error

### DIFF
--- a/lybic/lmcp.py
+++ b/lybic/lmcp.py
@@ -118,7 +118,6 @@ class ComputerUse:
     """ComputerUse is a client for lybic ComputerUse API(MCP and Restful)."""
     def __init__(self, client: LybicClient):
         self.client = client
-        self.mcp = client.mcp
 
     def parse_model_output(self, data: dto.ComputerUseParseRequestDto) -> dto.ComputerUseActionResponseDto:
         """

--- a/lybic/lybic.py
+++ b/lybic/lybic.py
@@ -81,9 +81,9 @@ class LybicClient:
         :return:
         """
         url = f"{self.endpoint}{path}"
-        headers = self.headers
+        headers = self.headers.copy()
         if method != "POST":
-            headers.pop("Content-Type")
+            headers.pop("Content-Type", None)
         response = requests.request(method, url, headers=headers,timeout=self.timeout, **kwargs)
         response.raise_for_status()
         return response

--- a/lybic/sandbox.py
+++ b/lybic/sandbox.py
@@ -26,6 +26,7 @@
 
 """sandbox.py provides the Sandbox API"""
 
+import requests
 import base64
 from io import BytesIO
 
@@ -115,7 +116,7 @@ class Sandbox:
         result = self.preview(sandbox_id)
         screenshot_url = result.screenShot
 
-        screenshot_response = self.client.request("GET",screenshot_url)
+        screenshot_response = requests.get(screenshot_url)
         screenshot_response.raise_for_status()
 
         img = Image.open(BytesIO(screenshot_response.content))


### PR DESCRIPTION
there are 3 bugs on client init has been fixed

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
1. fix header pop error when 'Content-type' is not exist  on header;
2. fix mcp client import error because of no item in LybicClient
3. fix get screenshot error because of baseurl problem
```
