### PR TITLE
fix: support for keyword arguments in MCP requests

### DIFF
--- a/lybic/lmcp.py
+++ b/lybic/lmcp.py
@@ -201,7 +201,8 @@ class ComputerUse:
             data = args[0]
         elif "data" in kwargs:
             data = kwargs["data"]
-            if not isinstance(data, dto.ComputerUseActionDto): raise TypeError(f"The 'data' argument must be of type {dto.ComputerUseActionDto.__name__}")
+            if not isinstance(data, dto.ComputerUseActionDto):
+                raise TypeError(f"The 'data' argument must be of type {dto.ComputerUseActionDto.__name__}")
         else:
             data = dto.ComputerUseActionDto(**kwargs)
         self.client.logger.debug(f"Execute computer use action request: {data.model_dump_json()}")


### PR DESCRIPTION
#### What this PR does / why we need it?

#### Summary of your change
- Add checks for "data" keyword argument in CreateMcpServerDto, ComputerUseParseRequestDto, and ComputerUseActionDto
- Improve flexibility and usability of MCP request functions by supporting both positional and keyword arguments


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
