### PR TITLE
fix: current connection details retrieval

### DIFF
--- a/lybic/dto.py
+++ b/lybic/dto.py
@@ -491,11 +491,6 @@ class SingleProjectResponseDto(ProjectResponseDto):
     Response DTO for a single project.
     """
 
-class SandboxConnectionDetail(BaseModel):
-    """
-    Represents the connection details for a sandbox.
-    """
-    connectDetails: ConnectDetails
 
 class SetMcpServerToSandboxResponseDto(BaseModel):
     """

--- a/lybic/sandbox.py
+++ b/lybic/sandbox.py
@@ -129,12 +129,12 @@ class Sandbox:
         self.client.logger.debug(f"Previewed sandbox {sandbox_id}")
         return dto.SandboxActionResponseDto.model_validate_json(response.text)
 
-    async def get_connection_details(self, sandbox_id: str)-> dto.SandboxConnectionDetail:
+    async def get_connection_details(self, sandbox_id: str)-> dto.ConnectDetails:
         """
         Get connection details for a sandbox
         """
         sandbox = await self.get(sandbox_id)
-        return dto.SandboxConnectionDetail(connectDetails=sandbox.connectDetails)
+        return sandbox.connectDetails
 
     async def get_screenshot(self, sandbox_id: str) -> Tuple[str, Image.Image, str]:
         """


### PR DESCRIPTION
#### What this PR does / why we need it?

#### Summary of your change
- Update SandboxConnectionDetail to inherit from BaseModel instead of SandboxListItem
- Add connectDetails field to SandboxConnectionDetail
- Simplify get_connection_details method in sandbox.py

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.

**Special notes for your reviewer**: IMPORT: THIS IS API CHANGE

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
