### PR TITLE
feat(sandbox): add extend_life method to prolong sandbox runtime

### DIFF
--- a/docs/example.md
+++ b/docs/example.md
@@ -478,7 +478,7 @@ This interface enables `Planner` to perform actions on the sandbox through Restf
     method: `extend_life(sandbox_id: str, seconds: int)`
     - args:
       - *sandbox_id: str ID of the sandbox
-      - *seconds: int Lifetime in seconds to extend the sandbox's lifetime (default: 3600 s, 1 hour, max: 31536000 s, 1 year)
+      - *seconds: int Lifetime in seconds to extend the sandbox's lifetime (default: 3600 s, 1 hour, max: 86400 s, 1 day)
     - return: None(if successful)
 
     ```python

--- a/docs/example.md
+++ b/docs/example.md
@@ -472,3 +472,20 @@ This interface enables `Planner` to perform actions on the sandbox through Restf
    print(f"Screenshot URL: {url}")
    image.show()
    ```
+
+6. Extend a sandbox's lifetime
+
+    method: `extend_life(sandbox_id: str, seconds: int)`
+    - args:
+    - *sandbox_id: str ID of the sandbox
+    - *seconds: int Lifetime in seconds to extend the sandbox's lifetime(default: 3600 s, 1 hour,max: 31536000 s, 1 year)
+    - return: None(if successful)
+
+    ```python
+    import asyncio
+    from lybic import Sandbox
+   
+    # Inside your async main function, with the client initialized:
+    sandbox = Sandbox(client)
+    await sandbox.extend_life(sandbox_id="SBX-xxxx", seconds=3600)
+    ```

--- a/docs/example.md
+++ b/docs/example.md
@@ -477,8 +477,8 @@ This interface enables `Planner` to perform actions on the sandbox through Restf
 
     method: `extend_life(sandbox_id: str, seconds: int)`
     - args:
-    - *sandbox_id: str ID of the sandbox
-    - *seconds: int Lifetime in seconds to extend the sandbox's lifetime(default: 3600 s, 1 hour,max: 31536000 s, 1 year)
+      - *sandbox_id: str ID of the sandbox
+      - *seconds: int Lifetime in seconds to extend the sandbox's lifetime (default: 3600 s, 1 hour, max: 31536000 s, 1 year)
     - return: None(if successful)
 
     ```python

--- a/lybic/dto.py
+++ b/lybic/dto.py
@@ -429,6 +429,11 @@ class CursorPosition(BaseModel):
     screenHeight: int
     screenIndex: int
 
+class ExtendSandboxDto(BaseModel):
+    """
+    Extend sandbox life request.
+    """
+    maxLifeSeconds: int =  Field(3600, description="Max life seconds of sandbox")
 
 class SandboxActionResponseDto(BaseModel):
     """

--- a/lybic/dto.py
+++ b/lybic/dto.py
@@ -433,7 +433,7 @@ class ExtendSandboxDto(BaseModel):
     """
     Extend sandbox life request.
     """
-    maxLifeSeconds: int = Field(3600, description="Max life seconds of sandbox", ge=1, le=31536000)
+    maxLifeSeconds: int = Field(3600, description="Max life seconds of sandbox", ge=30, le=60*60*24)
 
 class SandboxActionResponseDto(BaseModel):
     """

--- a/lybic/dto.py
+++ b/lybic/dto.py
@@ -433,7 +433,7 @@ class ExtendSandboxDto(BaseModel):
     """
     Extend sandbox life request.
     """
-    maxLifeSeconds: int =  Field(3600, description="Max life seconds of sandbox")
+    maxLifeSeconds: int = Field(3600, description="Max life seconds of sandbox", ge=1, le=31536000)
 
 class SandboxActionResponseDto(BaseModel):
     """

--- a/lybic/sandbox.py
+++ b/lybic/sandbox.py
@@ -129,6 +129,19 @@ class Sandbox:
         self.client.logger.debug(f"Previewed sandbox {sandbox_id}")
         return dto.SandboxActionResponseDto.model_validate_json(response.text)
 
+    async def extend_life(self, sandbox_id: str, seconds: int = 3600) -> None:
+        """
+        Extend life of a sandbox
+
+        The maximum life time of the sandbox in seconds. Default is 1 hour, max is 1 year.
+        """
+        self.client.logger.debug(f"Extending life of sandbox {sandbox_id}")
+        data = dto.ExtendSandboxDto(maxLifeSeconds=seconds)
+        await self.client.request(
+            "POST",
+            f"/api/orgs/{self.client.org_id}/sandboxes/{sandbox_id}/extend",
+            json=data.model_dump())
+
     async def get_connection_details(self, sandbox_id: str)-> dto.ConnectDetails:
         """
         Get connection details for a sandbox

--- a/lybic/sandbox.py
+++ b/lybic/sandbox.py
@@ -135,7 +135,10 @@ class Sandbox:
         Args:
             sandbox_id: The ID of the sandbox to extend.
             seconds: The duration in seconds to extend the sandbox's life.
-                     Default is 3600 (1 hour), max is 31536000 (1 year).
+                     Default is 3600 (1 hour), max is 86400 (1 day).
+                     The new max life time of the sandbox (relative to the current time) in seconds. Should not less
+                     than 30 seconds or more than 24 hours. Note that the total maximum lifetime of a sandbox should
+                     not longer than 13 days.
         """
         self.client.logger.debug(f"Extending life of sandbox {sandbox_id}")
         data = dto.ExtendSandboxDto(maxLifeSeconds=seconds)

--- a/lybic/sandbox.py
+++ b/lybic/sandbox.py
@@ -130,10 +130,12 @@ class Sandbox:
         return dto.SandboxActionResponseDto.model_validate_json(response.text)
 
     async def extend_life(self, sandbox_id: str, seconds: int = 3600) -> None:
-        """
-        Extend life of a sandbox
+        """Extend the life of a sandbox.
 
-        The maximum life time of the sandbox in seconds. Default is 1 hour, max is 1 year.
+        Args:
+            sandbox_id: The ID of the sandbox to extend.
+            seconds: The duration in seconds to extend the sandbox's life.
+                     Default is 3600 (1 hour), max is 31536000 (1 year).
         """
         self.client.logger.debug(f"Extending life of sandbox {sandbox_id}")
         data = dto.ExtendSandboxDto(maxLifeSeconds=seconds)

--- a/test/e2e.py
+++ b/test/e2e.py
@@ -75,6 +75,7 @@ async def test_sandbox(client:LybicClient):
 
     print("Test Delete Sandbox",await sandbox.delete(result.sandbox.id))
     print("Test Get Sandbox preview info",await sandbox.preview(result.sandbox.id))
+    print("Test Extend Sandbox",await sandbox.extend_life(result.sandbox.id))
     print("Test Get Sandbox connection details",await sandbox.get_connection_details(result.sandbox.id))
     # print("Test Get Sandbox screenshot",await sandbox.get_screenshot(result.sandbox.id))
 


### PR DESCRIPTION
#### What this PR does / why we need it?

#### Summary of your change
- Implement ExtendSandboxDto in dto.py for extend sandbox request
- Add extend_life method in Sandbox class to extend sandbox lifetime
- Update example.md with new method usage

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
