### PR TITLE
ci: add OpenAPI spec auto-sync and update e2e workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -37,12 +37,9 @@ jobs:
         run: |
           set -e 
           npm install -g @stoplight/prism-cli
-      - name: Get Api Doc
-        run: |
-          set -e 
-          wget https://lybic.ai/docs/openapi.json
+
       - name: Run Mock Server
-        run: prism mock ./openapi.json &
+        run: prism mock docs/openapi.json &
       - name: Wait for Mock Server
         run: sleep 5
       - name: Run Tests

--- a/.github/workflows/sync-openapi.yml
+++ b/.github/workflows/sync-openapi.yml
@@ -1,0 +1,66 @@
+# .github/workflows/sync-openapi.yml
+name: Sync OpenAPI Spec
+
+on:
+  workflow_dispatch: # Allows manual triggering
+  schedule:
+    - cron: '0 0 * * *' # Runs at 00:00 UTC every day
+
+jobs:
+  sync-spec:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Check for existing Pull Request
+        id: check_pr
+        run: |
+          PR_COUNT=$(gh pr list --head "update-openapi-json" --json number | jq length)
+          if [ "$PR_COUNT" -gt 0 ]; then
+            echo "An update PR already exists. Skipping workflow."
+            echo "stop_workflow=true" >> $GITHUB_OUTPUT
+          else
+            echo "No existing update PR found. Proceeding."
+            echo "stop_workflow=false" >> $GITHUB_OUTPUT
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download latest OpenAPI spec and compare
+        if: steps.check_pr.outputs.stop_workflow == 'false'
+        id: compare
+        run: |
+          curl -s -o openapi_new.json https://lybic.ai/docs/openapi.json
+          
+          # Use diff -q to quietly check for differences.
+          # If files are different, diff exits with 1, triggering the 'if' block.
+          if ! diff -q docs/openapi.json openapi_new.json; then
+            echo "OpenAPI spec has changed. An update is needed."
+            echo "needs_update=true" >> $GITHUB_OUTPUT
+            # Replace the old file with the new one for commit
+            mv openapi_new.json docs/openapi.json
+          else
+            echo "OpenAPI spec is up-to-date."
+            echo "needs_update=false" >> $GITHUB_OUTPUT
+            rm openapi_new.json
+          fi
+
+      - name: Create Pull Request
+        if: steps.compare.outputs.needs_update == 'true'
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          
+          git checkout -b update-openapi-json
+          git add docs/openapi.json
+          git commit -m "feat: Update OpenAPI specification" -m "Automated update of openapi.json from lybic.ai."
+          git push origin update-openapi-json
+          
+          gh pr create \
+            --title "feat: Update OpenAPI Specification" \
+            --body "This is an automated PR to sync the OpenAPI specification from [lybic.ai](https://lybic.ai/docs/openapi.json)." \
+            --base "main" \
+            --head "update-openapi-json"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
#### What this PR does / why we need it?

#### Summary of your change
- Add new workflow to automatically sync OpenAPI spec from lybic.ai
- Update e2e workflow to use local openapi.json file
- Implement daily scheduled check for OpenAPI spec updates
- Add logic to create a PR when OpenAPI spec changes

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
