### PR TITLE
ci: split release process into two workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,20 +1,17 @@
-name: Create Release
+name: Create Release Changelog And Version
 
 on:
   workflow_dispatch:
     inputs:
-      base_branch:
-        description: 'The base branch to create the release from (e.g., master)'
-        required: true
       new_tag:
-        description: 'The new tag to create (e.g., v0.4.0)'
+        description: 'The new tag(version) to create (e.g., v0.4.0)'
         required: true
       previous_tag:
         description: 'The previous tag for changelog generation (e.g., v0.3.58)'
         required: true
 
 jobs:
-  create_release:
+  create_changelog:
     runs-on: ubuntu-latest
     permissions:
       contents: write      # To push tags, branches, and commits
@@ -23,36 +20,16 @@ jobs:
       - name: Checkout master branch
         uses: actions/checkout@v5
         with:
-          ref: ${{ github.event.inputs.base_branch }}
           fetch-depth: 0 # Required for changelog generation from git history
 
       - name: Configure Git user
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-        
+
       - name: Create release branch
         run: |
-          git checkout -b release_${{ github.event.inputs.new_tag }}
-
-      - name: Update version in pyproject.toml
-        run: |
-          # Remove 'v' prefix from tag if present (e.g., v0.4.0 -> 0.4.0)
-          VERSION=${{ github.event.inputs.new_tag }}
-          VERSION=${VERSION#v}
-          
-          # Update version in pyproject.toml
-          sed -i "s/^version = \".*\"/version = \"$VERSION\"/" pyproject.toml
-          
-          # Commit the version update
-          git add pyproject.toml
-          git commit -m "build: bump pypi package version to $VERSION"
-          git push --set-upstream origin release_${{ github.event.inputs.new_tag }}
-
-      - name: Create and push new tag
-        run: |
-          git tag ${{ github.event.inputs.new_tag }}
-          git push origin ${{ github.event.inputs.new_tag }}
+          git checkout -b changelog_${{ github.event.inputs.new_tag }}
 
       - name: Generate changelog
         env:
@@ -66,56 +43,37 @@ jobs:
           echo "" >> changelog.md
           echo "Release timestamp: $(date +%Y-%m-%d)" >> changelog.md
           echo "" >> changelog.md
-          gh api repos/${{ github.repository }}/compare/${PREVIOUS_TAG}...${NEW_TAG} --jq '.commits[] | "- \(.commit.message | split("\n")[0]) (by @\(.author.login // .commit.author.name) in `\(.sha | tostring | .[0:7])`) "' >> changelog.md
+          gh api repos/${{ github.repository }}/compare/${PREVIOUS_TAG}...HEAD --jq '.commits[] | "- \(.commit.message | split("\n")[0]) (by @\(.author.login // .commit.author.name) in `\(.sha | tostring | .[0:7])`) "' >> changelog.md
           mkdir -p CHANGELOGS
           mv changelog.md CHANGELOGS/${NEW_TAG}-release.md
+
+      - name: Update version in pyproject.toml
+        run: |
+          # Remove 'v' prefix from tag if present (e.g., v0.4.0 -> 0.4.0)
+          VERSION=${{ github.event.inputs.new_tag }}
+          VERSION=${VERSION#v}
+
+          # Update version in pyproject.toml
+          sed -i "s/^version = \".*\"/version = \"$VERSION\"/" pyproject.toml
+
+          # Commit the version update
+          git add pyproject.toml
+          git commit -m "build: bump pypi package version to $VERSION"
+          git push --set-upstream origin changelog_${{ github.event.inputs.new_tag }}
 
       - name: Commit and push changelog
         run: |
           git add CHANGELOGS/${{ github.event.inputs.new_tag }}-release.md
           git commit -m "docs(changelog): Generate changelog for ${{ github.event.inputs.new_tag }}"
-          git push --set-upstream origin release_${{ github.event.inputs.new_tag }}
+          git push origin changelog_${{ github.event.inputs.new_tag }}
 
       - name: Create Changelog Pull Request
         env:
           GH_TOKEN: ${{ github.token }}
           NEW_TAG: ${{ github.event.inputs.new_tag }}
         run:  |
-          gh pr create --title "build: bump lybic-sdk-version to ${NEW_TAG}" --body "build: bump lybic-sdk-version to ${NEW_TAG}" --base master --head release_${{ github.event.inputs.new_tag }}
-          # gh pr merge --auto --squash # todo: To automatically merge, we need to enable the "Allow Automatic Merge" option in the repository Settings, but I couldn't find where this switch is
-
-  publish:
-    name: Publish Python Package to PyPI
-    needs: create_release
-    runs-on: ubuntu-latest
-    environment:
-      name: pypi
-      url: https://pypi.org/p/lybic
-    permissions:
-      id-token: write # Required for trusted publishing with OIDC
-
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v5
-      with:
-        ref: release_${{ github.event.inputs.new_tag }}
-
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.x'
-
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        pip install twine wheel setuptools build
-
-    - name: Build package
-      run: make build
-
-    - name: Publish package to PyPI
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.LYBIC_PYPI_KEY }}
-      run: make publish
+          gh pr create \
+            --title "build: bump lybic-sdk-version to ${NEW_TAG}" \
+            --body "build: bump lybic-sdk-version to ${NEW_TAG}" \
+            --base master \
+            --head changelog_${{ github.event.inputs.new_tag }}

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -1,0 +1,77 @@
+name: Tag and Release
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  tag-and-release:
+    if: |
+     github.event.pull_request.merged == true &&
+     startsWith(github.event.pull_request.title, 'build: bump lybic-sdk-version to')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write 
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Extract tag name
+        id: extract_tag
+        run: |
+          TAG_NAME=$(echo "${{ github.event.pull_request.title }}" | sed 's/build: bump lybic-sdk-version to //')
+          echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT
+
+      - name: Configure Git user
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          
+      - name: Create and push tag
+        run: |
+          git tag ${{ steps.extract_tag.outputs.tag_name }}
+          git push origin ${{ steps.extract_tag.outputs.tag_name }}
+
+      - name: Create Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create ${{ steps.extract_tag.outputs.tag_name }} \
+            --title "Release ${{ steps.extract_tag.outputs.tag_name }}" \
+            --notes-file "CHANGELOGS/${{ steps.extract_tag.outputs.tag_name }}-release.md"
+
+  publish-to-pypi:
+    name: Publish Python Package to PyPI
+    needs: tag-and-release
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/lybic
+    permissions:
+      id-token: write # Required for trusted publishing with OIDC
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v5
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install twine wheel setuptools build
+
+    - name: Build package
+      run: make build
+
+    - name: Publish package to PyPI
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.LYBIC_PYPI_KEY }}
+      run: make publish


### PR DESCRIPTION
#### What this PR does / why we need it?

#### Summary of your change
- Rename and restructure the existing release workflow
- Create a new workflow for tagging and releasing
- Update version and create changelog in a separate job
- Automatically extract tag name from pull request title
- Create release and publish to PyPI in the new workflow

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
