### PR TITLE
refactor(mcp): split MCP and ComputerUse into separate modules

### DIFF
--- a/lybic/__init__.py
+++ b/lybic/__init__.py
@@ -32,7 +32,10 @@ __version__ = "0.7.0"
 from .lybic import LybicClient
 
 # MCP Operations
-from .mcp import MCP,ComputerUse
+from .mcp import MCP
+
+#  Tools
+from .tools import ComputerUse
 
 # Project
 from .project import Project

--- a/lybic/lmcp.py
+++ b/lybic/lmcp.py
@@ -14,7 +14,8 @@ from lybic import MCP,ComputerUse
 # pylint: disable=unused-import
 
 import warnings
-from .mcp import MCP, ComputerUse
+from .mcp import MCP
+from .tools import ComputerUse
 
 warnings.warn(
     "The 'lybic.lmcp' module has been moved to 'lybic.mcp' and is deprecated. It will be removed in version 1.0. Please update your imports.",

--- a/lybic/pyautogui.py
+++ b/lybic/pyautogui.py
@@ -53,7 +53,7 @@ from typing import overload, Optional, Coroutine, List
 
 from lybic import dto
 from lybic.lybic import LybicClient
-from lybic.mcp import ComputerUse
+from lybic.tools import ComputerUse
 
 # pylint: disable=unused-argument,invalid-name,logging-fstring-interpolation
 class Pyautogui:

--- a/lybic/tools.py
+++ b/lybic/tools.py
@@ -113,10 +113,22 @@ class ComputerUse:
     async def execute_computer_use_action(self, sandbox_id: str, **kwargs) -> dto.SandboxActionResponseDto: ...
 
     async def execute_computer_use_action(self, sandbox_id: str, *args, **kwargs) -> dto.SandboxActionResponseDto:
-        """
-        Execute a computer use action
+        """Executes a computer use action in a specific sandbox.
 
-        is same as sandbox.Sandbox.execute_computer_use_action
+        Note: This method provides the same functionality as
+        `lybic.sandbox.Sandbox.execute_computer_use_action`.
+
+        Args:
+            sandbox_id: The ID of the sandbox to execute the action in.
+            *args: Supports passing `dto.ComputerUseActionDto` as a positional argument.
+            **kwargs: Supports passing `data` as a `dto.ComputerUseActionDto` or a `dict`,
+                or the fields of `dto.ComputerUseActionDto` directly as keyword arguments.
+
+        Returns:
+            A `dto.SandboxActionResponseDto` containing the result of the action.
+
+        Raises:
+            TypeError: If the 'data' argument is not of the expected type.
         """
         if args and isinstance(args[0], dto.ComputerUseActionDto):
             data = args[0]

--- a/lybic/tools.py
+++ b/lybic/tools.py
@@ -1,0 +1,138 @@
+# -*- coding: UTF-8 -*-
+#
+# Copyright (c) 2019-2025   Beijing Tingyu Technology Co., Ltd.
+# Copyright (c) 2025        Lybic Development Team <team@lybic.ai, lybic@tingyutech.com>
+# Copyright (c) 2025        Lu Yicheng <luyicheng@tingyutech.com>
+#
+# Author: AEnjoy <aenjoyable@163.com>
+#
+# These Terms of Service ("Terms") set forth the rules governing your access to and use of the website lybic.ai
+# ("Website"), our web applications, and other services (collectively, the "Services") provided by Beijing Tingyu
+# Technology Co., Ltd. ("Company," "we," "us," or "our"), a company registered in Haidian District, Beijing. Any
+# breach of these Terms may result in the suspension or termination of your access to the Services.
+# By accessing and using the Services and/or the Website, you represent that you are at least 18 years old,
+# acknowledge that you have read and understood these Terms, and agree to be bound by them. By using or accessing
+# the Services and/or the Website, you further represent and warrant that you have the legal capacity and authority
+# to agree to these Terms, whether as an individual or on behalf of a company. If you do not agree to all of these
+# Terms, do not access or use the Website or Services.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+"""
+lybic.tools:
+ComputerUse tools
+"""
+from typing import overload
+
+from lybic import dto
+from lybic.lybic import LybicClient
+from lybic._api import deprecated
+
+class ComputerUse:
+    """ComputerUse is an async client for lybic ComputerUse API(MCP and Restful)."""
+    def __init__(self, client: LybicClient):
+        self.client = client
+    @deprecated(
+        since="0.7.0",
+        removal="1.0.0",
+        message="Use parse_llm_output instead"
+    )
+    @overload
+    async def parse_model_output(self, data: dto.ComputerUseParseRequestDto) -> dto.ComputerUseActionResponseDto: ...
+    @deprecated(
+        since="0.7.0",
+        removal="1.0.0",
+        message="Use parse_llm_output instead"
+    )
+    @overload
+    async def parse_model_output(self, **kwargs) -> dto.ComputerUseActionResponseDto: ...
+    @deprecated(
+        since="0.7.0",
+        removal="1.0.0",
+        message="Use parse_llm_output instead"
+    )
+    async def parse_model_output(self, *args, **kwargs) -> dto.ComputerUseActionResponseDto:
+        """
+        parse doubao-ui-tars output
+
+        :param data:
+        :return:
+        """
+        if args and isinstance(args[0], dto.ComputerUseParseRequestDto):
+            data = args[0]
+        elif "data" in kwargs and isinstance(kwargs["data"], dto.ComputerUseParseRequestDto):
+            data = kwargs["data"]
+        else:
+            data = dto.ComputerUseParseRequestDto(**kwargs)
+        self.client.logger.debug(f"Parse model output request: {data.model_dump_json()}")
+        response = await self.client.request(
+            "POST",
+            "/api/computer-use/parse",
+            json=data.model_dump(exclude_none=True))
+        self.client.logger.debug(f"Parse model output response: {response.text}")
+        return dto.ComputerUseActionResponseDto.model_validate_json(response.text)
+    async def parse_llm_output(
+        self, model_type: dto.ModelType | str, llm_output: str
+    ) -> dto.ComputerUseActionResponseDto:
+        """Parse LLM output to computer use actions.
+
+        Args:
+            model_type: The type of the large language model.
+            llm_output: The text output from the large language model.
+
+        Returns:
+            A DTO containing the parsed computer use actions.
+        """
+        if isinstance(model_type, dto.ModelType):
+            model = model_type.value
+        elif isinstance(model_type, str):
+            valid_models = [item.value for item in dto.ModelType]
+            if model_type not in valid_models:
+                raise ValueError(f"Invalid model_type: {model_type}. Must be one of {valid_models}")
+            model = model_type
+        else:
+            raise TypeError("model_type must be either dto.ModelType or str")
+
+        response = await self.client.request(
+            "POST",
+            f"/api/computer-use/parse/{model}",
+            json={"textContent": llm_output},
+        )
+        self.client.logger.debug(f"Parse model output response: {response.text}")
+        return dto.ComputerUseActionResponseDto.model_validate_json(response.text)
+
+    @overload
+    async def execute_computer_use_action(self, sandbox_id: str,
+                                    data: dto.ComputerUseActionDto) -> dto.SandboxActionResponseDto: ...
+    @overload
+    async def execute_computer_use_action(self, sandbox_id: str, **kwargs) -> dto.SandboxActionResponseDto: ...
+
+    async def execute_computer_use_action(self, sandbox_id: str, *args, **kwargs) -> dto.SandboxActionResponseDto:
+        """
+        Execute a computer use action
+
+        is same as sandbox.Sandbox.execute_computer_use_action
+        """
+        if args and isinstance(args[0], dto.ComputerUseActionDto):
+            data = args[0]
+        elif "data" in kwargs:
+            data_arg = kwargs["data"]
+            if isinstance(data_arg, dto.ComputerUseActionDto):
+                data = data_arg
+            elif isinstance(data_arg, dict):
+                data = dto.ComputerUseActionDto(**data_arg)
+            else:
+                raise TypeError(f"The 'data' argument must be of type {dto.ComputerUseActionDto.__name__} or dict")
+        else:
+            data = dto.ComputerUseActionDto(**kwargs)
+        self.client.logger.debug(f"Execute computer use action request: {data.model_dump_json()}")
+        response = await self.client.request("POST",
+                                       f"/api/orgs/{self.client.org_id}/sandboxes/{sandbox_id}/actions/computer-use",
+                                       json=data.model_dump(exclude_none=True))
+        self.client.logger.debug(f"Execute computer use action response: {response.text}")
+        return dto.SandboxActionResponseDto.model_validate_json(response.text)


### PR DESCRIPTION
#### What this PR does / why we need it? Summary of your change
- Move ComputerUse class from mcp.py to new tools.py file
- Update imports in __init__.py and lmcp.py to reflect new module structure
- Remove deprecated import in mcp.py


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.

**Special notes for your reviewer**:
