### PR TITLE
🚧feat: add OSWorld module for cross-platform workflow automation

### DIFF
--- a/lybic/__init__.py
+++ b/lybic/__init__.py
@@ -37,6 +37,9 @@ from .mcp import MCP, Mcp
 #  Tools
 from .tools import ComputerUse
 
+# osworld
+from .osworld import OSWorld
+
 # Project
 from .project import Project
 
@@ -54,6 +57,7 @@ __all__ = [
     "LybicClient",
     "MCP",
     "ComputerUse",
+    "OSWorld",
     "Project",
     "Pyautogui",
     "Sandbox",

--- a/lybic/osworld.py
+++ b/lybic/osworld.py
@@ -1,0 +1,81 @@
+# -*- coding: UTF-8 -*-
+#
+# Copyright (c) 2019-2025   Beijing Tingyu Technology Co., Ltd.
+# Copyright (c) 2025        Lybic Development Team <team@lybic.ai, lybic@tingyutech.com>
+#
+# These Terms of Service ("Terms") set forth the rules governing your access to and use of the website lybic.ai
+# ("Website"), our web applications, and other services (collectively, the "Services") provided by Beijing Tingyu
+# Technology Co., Ltd. ("Company," "we," "us," or "our"), a company registered in Haidian District, Beijing. Any
+# breach of these Terms may result in the suspension or termination of your access to the Services.
+# By accessing and using the Services and/or the Website, you represent that you are at least 18 years old,
+# acknowledge that you have read and understood these Terms, and agree to be bound by them. By using or accessing
+# the Services and/or the Website, you further represent and warrant that you have the legal capacity and authority
+# to agree to these Terms, whether as an individual or on behalf of a company. If you do not agree to all of these
+# Terms, do not access or use the Website or Services.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+"""
+In the OSWorld benchmark, in addition to common GUI keyboard and mouse operations, there are also several shortcut action spaces.
+This expanded action space allows agents to perform more actions in smaller steps, enabling more functionality,
+ultimately significantly improving the user experience.
+This file adapts the action spaces of several well-known OSWorld agents to improve scalability and simplify developer
+work in complex AI workflows.
+
+Please view: https://github.com/xlang-ai/OSWorld/tree/main/mm_agents
+"""
+import sys
+import time
+
+from lybic.pyautogui import Pyautogui
+from lybic.lybic import LybicClient
+
+
+class OSWorld(Pyautogui):
+    """
+    OSWorld is a Python library for controlling the mouse and keyboard on Windows, macOS, and Linux.
+    It provides a simple but effective way to automate tasks on these operating systems.
+    """
+    def __init__(self, client: LybicClient, sandbox_id: str):
+        super().__init__(client, sandbox_id)
+        self.platform: str = sys.platform.lower()
+
+    def open(self,app_or_filename:str):
+        """
+        Opens an application or file.
+
+        :param app_or_filename:
+        :return:
+        """
+        if self.platform.startswith("darwin"):
+            # macOS: Command+Space to open Spotlight
+            self.hotkey("command", "space", interval=0.2)
+            time.sleep(0.5)
+            self.typewrite(app_or_filename)
+            time.sleep(1.0)
+            self.press("enter")
+            time.sleep(0.5)
+        elif self.platform.startswith("linux"):
+            # Linux: Win key to open application menu
+            self.press("super")
+            time.sleep(0.5)
+            self.typewrite(app_or_filename)
+            time.sleep(1.0)
+            self.press("enter")
+            time.sleep(0.5)
+        elif self.platform.startswith("win"):
+            # Windows: Win+R to open Run dialog
+            self.hotkey("win", "r", interval=0.1)
+            time.sleep(0.5)
+            self.typewrite(app_or_filename)
+            time.sleep(1.0)
+            self.press("enter")
+            time.sleep(1.0)
+        else:
+            raise NotImplementedError(f"Open not supported on platform: {self.platform}")


### PR DESCRIPTION
#### What this PR does / why we need it? Summary of your change
- Introduce OSWorld class for controlling mouse and keyboard on Windows, macOS, and Linux
- Implement open method to launch applications or files across different platforms
- Update __init__.py to include OSWorld module and add it to __all__

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.

**Special notes for your reviewer**:
