### PR TITLE
feat: add MobileUseActionResponseDto and MobileUse client for mobile …

### DIFF
--- a/lybic/dto.py
+++ b/lybic/dto.py
@@ -485,3 +485,19 @@ class GetShapesResponseDto(RootModel):
 
     def __getitem__(self, item):
         return self.root[item]
+
+
+class MobileUseActionResponseDto(BaseModel):
+    """
+    Response DTO containing a list of parsed mobile use actions.
+    """
+    unknown: Optional[str] = None
+    thoughts: Optional[str] = None
+    memory: Optional[str] = None
+
+    actions: List[MobileUseAction]
+    class Config:
+        """
+        Configuration for Pydantic model.
+        """
+        extra = json_extra_fields_policy

--- a/lybic/tools.py
+++ b/lybic/tools.py
@@ -26,10 +26,19 @@
 """
 lybic.tools:
 ComputerUse tools
+MobileUse tools
 """
 from typing import overload
 
-from lybic import dto
+from lybic.dto import (
+    ParseTextRequestDto,
+    ComputerUseParseRequestDto,
+    ComputerUseActionResponseDto,
+    ModelType,
+    ComputerUseActionDto,
+    SandboxActionResponseDto,
+    MobileUseActionResponseDto
+)
 from lybic.lybic import LybicClient
 from lybic._api import deprecated
 
@@ -43,42 +52,42 @@ class ComputerUse:
         message="Use parse_llm_output instead"
     )
     @overload
-    async def parse_model_output(self, data: dto.ComputerUseParseRequestDto) -> dto.ComputerUseActionResponseDto: ...
+    async def parse_model_output(self, data: ComputerUseParseRequestDto) -> ComputerUseActionResponseDto: ...
     @deprecated(
         since="0.7.0",
         removal="1.0.0",
         message="Use parse_llm_output instead"
     )
     @overload
-    async def parse_model_output(self, **kwargs) -> dto.ComputerUseActionResponseDto: ...
+    async def parse_model_output(self, **kwargs) -> ComputerUseActionResponseDto: ...
     @deprecated(
         since="0.7.0",
         removal="1.0.0",
         message="Use parse_llm_output instead"
     )
-    async def parse_model_output(self, *args, **kwargs) -> dto.ComputerUseActionResponseDto:
+    async def parse_model_output(self, *args, **kwargs) -> ComputerUseActionResponseDto:
         """
         parse doubao-ui-tars output
 
         :param data:
         :return:
         """
-        if args and isinstance(args[0], dto.ComputerUseParseRequestDto):
+        if args and isinstance(args[0], ComputerUseParseRequestDto):
             data = args[0]
-        elif "data" in kwargs and isinstance(kwargs["data"], dto.ComputerUseParseRequestDto):
+        elif "data" in kwargs and isinstance(kwargs["data"], ComputerUseParseRequestDto):
             data = kwargs["data"]
         else:
-            data = dto.ComputerUseParseRequestDto(**kwargs)
+            data = ComputerUseParseRequestDto(**kwargs)
         self.client.logger.debug(f"Parse model output request: {data.model_dump_json()}")
         response = await self.client.request(
             "POST",
             "/api/computer-use/parse",
             json=data.model_dump(exclude_none=True))
         self.client.logger.debug(f"Parse model output response: {response.text}")
-        return dto.ComputerUseActionResponseDto.model_validate_json(response.text)
+        return ComputerUseActionResponseDto.model_validate_json(response.text)
     async def parse_llm_output(
-        self, model_type: dto.ModelType | str, llm_output: str
-    ) -> dto.ComputerUseActionResponseDto:
+        self, model_type: ModelType | str, llm_output: str
+    ) -> ComputerUseActionResponseDto:
         """Parse LLM output to computer use actions.
 
         Args:
@@ -88,10 +97,10 @@ class ComputerUse:
         Returns:
             A DTO containing the parsed computer use actions.
         """
-        if isinstance(model_type, dto.ModelType):
+        if isinstance(model_type, ModelType):
             model = model_type.value
         elif isinstance(model_type, str):
-            valid_models = [item.value for item in dto.ModelType]
+            valid_models = [item.value for item in ModelType]
             if model_type not in valid_models:
                 raise ValueError(f"Invalid model_type: {model_type}. Must be one of {valid_models}")
             model = model_type
@@ -101,10 +110,10 @@ class ComputerUse:
         response = await self.client.request(
             "POST",
             f"/api/computer-use/parse/{model}",
-            json={"textContent": llm_output},
+            json=ParseTextRequestDto(textContent=llm_output).model_dump(),
         )
         self.client.logger.debug(f"Parse model output response: {response.text}")
-        return dto.ComputerUseActionResponseDto.model_validate_json(response.text)
+        return ComputerUseActionResponseDto.model_validate_json(response.text)
 
     @deprecated(
         since="0.8.0",
@@ -113,21 +122,21 @@ class ComputerUse:
     )
     @overload
     async def execute_computer_use_action(self, sandbox_id: str,
-                                    data: dto.ComputerUseActionDto) -> dto.SandboxActionResponseDto: ...
+                                    data: ComputerUseActionDto) -> SandboxActionResponseDto: ...
     @deprecated(
         since="0.8.0",
         removal="1.0.0",
         message="Use `lybic.sandbox.Sandbox.execute_sandbox_action` instead."
     )
     @overload
-    async def execute_computer_use_action(self, sandbox_id: str, **kwargs) -> dto.SandboxActionResponseDto: ...
+    async def execute_computer_use_action(self, sandbox_id: str, **kwargs) -> SandboxActionResponseDto: ...
 
     @deprecated(
         since="0.8.0",
         removal="1.0.0",
         message="Use `lybic.sandbox.Sandbox.execute_sandbox_action` instead."
     )
-    async def execute_computer_use_action(self, sandbox_id: str, *args, **kwargs) -> dto.SandboxActionResponseDto:
+    async def execute_computer_use_action(self, sandbox_id: str, *args, **kwargs) -> SandboxActionResponseDto:
         """Executes a computer use action in a specific sandbox.
 
         Note: This method provides the same functionality as
@@ -145,21 +154,56 @@ class ComputerUse:
         Raises:
             TypeError: If the 'data' argument is not of the expected type.
         """
-        if args and isinstance(args[0], dto.ComputerUseActionDto):
+        if args and isinstance(args[0], ComputerUseActionDto):
             data = args[0]
         elif "data" in kwargs:
             data_arg = kwargs["data"]
-            if isinstance(data_arg, dto.ComputerUseActionDto):
+            if isinstance(data_arg, ComputerUseActionDto):
                 data = data_arg
             elif isinstance(data_arg, dict):
-                data = dto.ComputerUseActionDto(**data_arg)
+                data = ComputerUseActionDto(**data_arg)
             else:
-                raise TypeError(f"The 'data' argument must be of type {dto.ComputerUseActionDto.__name__} or dict")
+                raise TypeError(f"The 'data' argument must be of type {ComputerUseActionDto.__name__} or dict")
         else:
-            data = dto.ComputerUseActionDto(**kwargs)
+            data = ComputerUseActionDto(**kwargs)
         self.client.logger.debug(f"Execute computer use action request: {data.model_dump_json()}")
         response = await self.client.request("POST",
                                        f"/api/orgs/{self.client.org_id}/sandboxes/{sandbox_id}/actions/computer-use",
                                        json=data.model_dump(exclude_none=True))
         self.client.logger.debug(f"Execute computer use action response: {response.text}")
-        return dto.SandboxActionResponseDto.model_validate_json(response.text)
+        return SandboxActionResponseDto.model_validate_json(response.text)
+
+class MobileUse:
+    """MobileUse is an async client for lybic MobileUse API(MCP and Restful)."""
+    def __init__(self, client: LybicClient):
+        self.client = client
+
+    async def parse_llm_output(
+        self, model_type: ModelType | str, llm_output: str
+    ) -> MobileUseActionResponseDto:
+        """Parse LLM output to mobile use actions.
+
+        Args:
+            model_type: The type of the large language model.
+            llm_output: The text output from the large language model.
+
+        Returns:
+            A DTO containing the parsed mobile use actions.
+        """
+        if isinstance(model_type, ModelType):
+            model = model_type.value
+        elif isinstance(model_type, str):
+            valid_models = [item.value for item in ModelType]
+            if model_type not in valid_models:
+                raise ValueError(f"Invalid model_type: {model_type}. Must be one of {valid_models}")
+            model = model_type
+        else:
+            raise TypeError("model_type must be either dto.ModelType or str")
+
+        response = await self.client.request(
+            "POST",
+            f"/api/mobile-use/parse/{model}",
+            json=ParseTextRequestDto(textContent=llm_output).model_dump(),
+        )
+        self.client.logger.debug(f"Parse model output response: {response.text}")
+        return MobileUseActionResponseDto.model_validate_json(response.text)


### PR DESCRIPTION
…use actions

#### What this PR does / why we need it? Summary of your change

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

#### Please indicate you've done the following:
This pull request adds support for mobile use actions to the codebase, alongside refactoring and improving type usage for computer use actions. The main changes include introducing a new DTO for mobile use actions, adding a new `MobileUse` client class, and updating imports and type references for consistency.

**Mobile Use API Support:**

* Added `MobileUseActionResponseDto` to `lybic/dto.py` to represent parsed mobile use actions responses.
* Introduced the `MobileUse` async client class to `lybic/tools.py`, enabling parsing of LLM output into mobile use actions via the new API endpoint.

**Refactoring and Consistency Improvements:**

* Updated imports in `lybic/tools.py` to use direct references for DTOs and types, improving clarity and maintainability.
* Refactored all type references in `lybic/tools.py` from `dto.` prefix to direct imports for DTOs and types, including `ComputerUseParseRequestDto`, `ComputerUseActionResponseDto`, `ModelType`, `ComputerUseActionDto`, and `SandboxActionResponseDto`. [[1]](diffhunk://#diff-12e542ac30c28c99691c15b68fc9fe3f594da3b6e662589a0e239d22e0b56851L46-R90) [[2]](diffhunk://#diff-12e542ac30c28c99691c15b68fc9fe3f594da3b6e662589a0e239d22e0b56851L91-R103) [[3]](diffhunk://#diff-12e542ac30c28c99691c15b68fc9fe3f594da3b6e662589a0e239d22e0b56851L104-R116) [[4]](diffhunk://#diff-12e542ac30c28c99691c15b68fc9fe3f594da3b6e662589a0e239d22e0b56851L116-R139) [[5]](diffhunk://#diff-12e542ac30c28c99691c15b68fc9fe3f594da3b6e662589a0e239d22e0b56851L148-R209)

**API Usage Improvements:**

* Updated request payload construction for parsing LLM output to use `ParseTextRequestDto.model_dump()` for both computer and mobile use actions. [[1]](diffhunk://#diff-12e542ac30c28c99691c15b68fc9fe3f594da3b6e662589a0e239d22e0b56851L104-R116) [[2]](diffhunk://#diff-12e542ac30c28c99691c15b68fc9fe3f594da3b6e662589a0e239d22e0b56851L148-R209)
- [ ] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.

**Special notes for your reviewer**:
