### PR TITLE
refactor: streamline Pydantic model configurations by removing redund…

### DIFF
--- a/lybic/__init__.py
+++ b/lybic/__init__.py
@@ -28,6 +28,13 @@
 
 __version__ = "0.10.0"
 
+# Strategy for handling extra fields in the lybic api response
+# "ignore" means ignore extra fields, which will ensure that your SDK version remains compatible with the Lybic platform,
+# but it may cause compatibility issues with future versions of the SDK.
+# "forbid" means that the SDK will throw an error if it encounters extra fields in the response, which will force you to
+# update your SDK when the Lybic platform is updated, and may have a certain impact on your online environment.
+from .dto import json_extra_fields_policy
+
 # Lybic Client
 from .authentication import LybicAuth
 from .lybic import LybicClient
@@ -61,6 +68,8 @@ __all__ = [
     "Pyautogui",
     "Sandbox",
     "Stats",
+
+    "json_extra_fields_policy",
 ]
 
 def __dir__() -> list[str]:

--- a/lybic/action/android.py
+++ b/lybic/action/android.py
@@ -28,34 +28,14 @@
 from typing import Literal
 from pydantic import BaseModel
 
-from .common import json_extra_fields_policy
-
 class AndroidBackAction(BaseModel):
     """
     Press the back button on Android device.
     """
     type: Literal["android:back"] = "android:back"
 
-    class Config:
-        """
-        Configuration for Pydantic model.
-        """
-        extra = json_extra_fields_policy
-        # Allow population of fields with default values
-        validate_assignment = True
-        exclude_none = True
-
 class AndroidHomeAction(BaseModel):
     """
     Press the home button on Android device.
     """
     type: Literal["android:home"] = "android:home"
-
-    class Config:
-        """
-        Configuration for Pydantic model.
-        """
-        extra = json_extra_fields_policy
-        # Allow population of fields with default values
-        validate_assignment = True
-        exclude_none = True

--- a/lybic/action/common.py
+++ b/lybic/action/common.py
@@ -28,12 +28,6 @@
 from typing import Literal, Optional, Union
 from pydantic import BaseModel
 
-# pylint: disable=invalid-name
-
-# Strategy for handling extra fields in the lybic api response
-json_extra_fields_policy = "ignore"
-
-
 class PixelLength(BaseModel):
     """
     Represents a length in pixels.

--- a/lybic/action/common.py
+++ b/lybic/action/common.py
@@ -41,14 +41,6 @@ class PixelLength(BaseModel):
     type: Literal["px"] = "px"
     value: int
 
-    class Config:
-        """
-        Configuration for Pydantic model.
-        """
-        extra = json_extra_fields_policy
-        validate_assignment = True
-        exclude_none = True
-
 
 class FractionalLength(BaseModel):
     """
@@ -57,15 +49,6 @@ class FractionalLength(BaseModel):
     type: Literal["/"] = "/"
     numerator: int
     denominator: int
-
-    class Config:
-        """
-        Configuration for Pydantic model.
-        """
-        extra = json_extra_fields_policy
-        validate_assignment = True
-        exclude_none = True
-
 
 Length = Union[PixelLength, FractionalLength]
 
@@ -76,30 +59,12 @@ class ClientUserTakeoverAction(BaseModel):
     """
     type: Literal["client:user-takeover"] = "client:user-takeover"
 
-    class Config:
-        """
-        Configuration for Pydantic model.
-        """
-        extra = json_extra_fields_policy
-        # Allow population of fields with default values
-        validate_assignment = True
-        exclude_none = True
-
 
 class ScreenshotAction(BaseModel):
     """
     Represents an action to take a screenshot.
     """
     type: Literal["screenshot"] = "screenshot"
-
-    class Config:
-        """
-        Configuration for Pydantic model.
-        """
-        extra = json_extra_fields_policy
-        # Allow population of fields with default values
-        validate_assignment = True
-        exclude_none = True
 
 
 class WaitAction(BaseModel):
@@ -109,15 +74,6 @@ class WaitAction(BaseModel):
     type: Literal["wait"] = "wait"
     duration: int
 
-    class Config:
-        """
-        Configuration for Pydantic model.
-        """
-        extra = json_extra_fields_policy
-        # Allow population of fields with default values
-        validate_assignment = True
-        exclude_none = True
-
 
 class FinishedAction(BaseModel):
     """
@@ -126,15 +82,6 @@ class FinishedAction(BaseModel):
     type: Literal["finished"] = "finished"
     message: Optional[str] = None
 
-    class Config:
-        """
-        Configuration for Pydantic model.
-        """
-        extra = json_extra_fields_policy
-        # Allow population of fields with default values
-        validate_assignment = True
-        exclude_none = True
-
 
 class FailedAction(BaseModel):
     """
@@ -142,15 +89,6 @@ class FailedAction(BaseModel):
     """
     type: Literal["failed"] = "failed"
     message: Optional[str] = None
-
-    class Config:
-        """
-        Configuration for Pydantic model.
-        """
-        extra = json_extra_fields_policy
-        # Allow population of fields with default values
-        validate_assignment = True
-        exclude_none = True
 
 
 CommonAction = Union[

--- a/lybic/action/computer.py
+++ b/lybic/action/computer.py
@@ -28,7 +28,7 @@
 from typing import Literal, Optional, Union
 from pydantic import BaseModel, Field
 
-from .common import Length, json_extra_fields_policy, ScreenshotAction, WaitAction, FinishedAction, FailedAction, ClientUserTakeoverAction
+from .common import Length, ScreenshotAction, WaitAction, FinishedAction, FailedAction, ClientUserTakeoverAction
 
 class MouseClickAction(BaseModel):
     """
@@ -41,14 +41,6 @@ class MouseClickAction(BaseModel):
     relative: bool = Field(False, description="Whether the coordinates are relative to the current mouse position")
     holdKey: Optional[str] = Field(None, description="Key to hold down during click, in xdotool key syntax. Example: \"ctrl\", \"alt\", \"alt+shift\"")
 
-    class Config:
-        """
-        Configuration for Pydantic model.
-        """
-        extra = json_extra_fields_policy
-        # Allow population of fields with default values
-        validate_assignment = True
-        exclude_none = True
 
 class MouseTripleClickAction(BaseModel):
     """
@@ -61,14 +53,6 @@ class MouseTripleClickAction(BaseModel):
     relative: bool = Field(False, description="Whether the coordinates are relative to the current mouse position.")
     holdKey: Optional[str] = Field(None, description="Key to hold down during triple click, in xdotool key syntax. Example: \"ctrl\", \"alt\", \"alt+shift\"")
 
-    class Config:
-        """
-        Configuration for Pydantic model.
-        """
-        extra = json_extra_fields_policy
-        # Allow population of fields with default values
-        validate_assignment = True
-        exclude_none = True
 
 class MouseDoubleClickAction(BaseModel):
     """
@@ -81,14 +65,6 @@ class MouseDoubleClickAction(BaseModel):
     relative: bool = Field(False, description="Whether the coordinates are relative to the current mouse position")
     holdKey: Optional[str] = Field(None, description="Key to hold down during click, in xdotool key syntax. Example: \"ctrl\", \"alt\", \"alt+shift\"")
 
-    class Config:
-        """
-        Configuration for Pydantic model.
-        """
-        extra = json_extra_fields_policy
-        # Allow population of fields with default values
-        validate_assignment = True
-        exclude_none = True
 
 
 class MouseMoveAction(BaseModel):
@@ -100,15 +76,6 @@ class MouseMoveAction(BaseModel):
     y: Length
     relative: bool = Field(False, description="Whether the coordinates are relative to the current mouse position")
     holdKey: Optional[str] = Field(None, description="Key to hold down during move, in xdotool key syntax. Example: \"ctrl\", \"alt\", \"alt+shift\"")
-
-    class Config:
-        """
-        Configuration for Pydantic model.
-        """
-        extra = json_extra_fields_policy
-        # Allow population of fields with default values
-        validate_assignment = True
-        exclude_none = True
 
 
 class MouseScrollAction(BaseModel):
@@ -122,15 +89,6 @@ class MouseScrollAction(BaseModel):
     stepHorizontal: int
     relative: bool = Field(False, description="Whether the coordinates are relative to the current mouse position")
     holdKey: Optional[str] = Field(None, description="Key to hold down during scroll, in xdotool key syntax. Example: \"ctrl\", \"alt\", \"alt+shift\"")
-
-    class Config:
-        """
-        Configuration for Pydantic model.
-        """
-        extra = json_extra_fields_policy
-        # Allow population of fields with default values
-        validate_assignment = True
-        exclude_none = True
 
 
 class MouseDragAction(BaseModel):
@@ -147,15 +105,6 @@ class MouseDragAction(BaseModel):
     button: int = Field(..., description="Mouse button flag combination. 1: left, 2: right, 4: middle, 8: back, 16: forward; add them together to press multiple buttons at once.")
     holdKey: Optional[str] = Field(None, description="Key to hold down during drag, in xdotool key syntax. Example: \"ctrl\", \"alt\", \"alt+shift\"")
 
-    class Config:
-        """
-        Configuration for Pydantic model.
-        """
-        extra = json_extra_fields_policy
-        # Allow population of fields with default values
-        validate_assignment = True
-        exclude_none = True
-
 
 class KeyboardTypeAction(BaseModel):
     """
@@ -164,15 +113,6 @@ class KeyboardTypeAction(BaseModel):
     type: Literal["keyboard:type"] =  "keyboard:type"
     content: str
     treatNewLineAsEnter: bool = Field(False, description="Whether to treat line breaks as enter. If true, any line breaks(\\n) in content will be treated as enter key press, and content will be split into multiple lines.")
-
-    class Config:
-        """
-        Configuration for Pydantic model.
-        """
-        extra = json_extra_fields_policy
-        # Allow population of fields with default values
-        validate_assignment = True
-        exclude_none = True
 
 
 class KeyboardHotkeyAction(BaseModel):
@@ -183,30 +123,12 @@ class KeyboardHotkeyAction(BaseModel):
     keys: str
     duration: Optional[int] = Field(None, description="Duration in milliseconds. If specified, the hotkey will be held for a while and then released.")
 
-    class Config:
-        """
-        Configuration for Pydantic model.
-        """
-        extra = json_extra_fields_policy
-        # Allow population of fields with default values
-        validate_assignment = True
-        exclude_none = True
-
-
 class KeyDownAction(BaseModel):
     """
     Press ONE key down, in xdotool key syntax. Only use this action if hotkey or type cannot satisfy your needs.
     """
     type: Literal["key:down"]= "key:down"
     key: str
-
-    class Config:
-        """
-        Configuration for Pydantic model.
-        """
-        extra = json_extra_fields_policy
-        validate_assignment = True
-        exclude_none = True
 
 
 class KeyUpAction(BaseModel):
@@ -215,15 +137,6 @@ class KeyUpAction(BaseModel):
     """
     type: Literal["key:up"] = "key:up"
     key: str
-
-    class Config:
-        """
-        Configuration for Pydantic model.
-        """
-        extra = json_extra_fields_policy
-        validate_assignment = True
-        exclude_none = True
-
 
 ComputerUseAction = Union[
     MouseClickAction,

--- a/lybic/action/os.py
+++ b/lybic/action/os.py
@@ -28,24 +28,12 @@
 from typing import Literal
 from pydantic import BaseModel
 
-from .common import json_extra_fields_policy
-
-
 class OsStartAppAction(BaseModel):
     """
     Start an app by its package name.
     """
     type: Literal["os:startApp"] = "os:startApp"
     packageName: str
-
-    class Config:
-        """
-        Configuration for Pydantic model.
-        """
-        extra = json_extra_fields_policy
-        # Allow population of fields with default values
-        validate_assignment = True
-        exclude_none = True
 
 class OsStartAppByNameAction(BaseModel):
     """
@@ -54,41 +42,14 @@ class OsStartAppByNameAction(BaseModel):
     type: Literal["os:startAppByName"] = "os:startAppByName"
     name: str
 
-    class Config:
-        """
-        Configuration for Pydantic model.
-        """
-        extra = json_extra_fields_policy
-        # Allow population of fields with default values
-        validate_assignment = True
-        exclude_none = True
-
 class OsCloseAppAction(BaseModel):
     """
     Close the current app.
     """
     type: Literal["os:closeApp"] = "os:closeApp"
 
-    class Config:
-        """
-        Configuration for Pydantic model.
-        """
-        extra = json_extra_fields_policy
-        # Allow population of fields with default values
-        validate_assignment = True
-        exclude_none = True
-
 class OsListAppsAction(BaseModel):
     """
     List installed apps.
     """
     type: Literal["os:listApps"] = "os:listApps"
-
-    class Config:
-        """
-        Configuration for Pydantic model.
-        """
-        extra = json_extra_fields_policy
-        # Allow population of fields with default values
-        validate_assignment = True
-        exclude_none = True

--- a/lybic/action/touch.py
+++ b/lybic/action/touch.py
@@ -28,7 +28,7 @@
 from typing import Literal
 from pydantic import BaseModel
 
-from .common import Length, json_extra_fields_policy
+from .common import Length
 
 
 class TouchTapAction(BaseModel):
@@ -39,14 +39,6 @@ class TouchTapAction(BaseModel):
     x: Length
     y: Length
 
-    class Config:
-        """
-        Configuration for Pydantic model.
-        """
-        extra = json_extra_fields_policy
-        # Allow population of fields with default values
-        validate_assignment = True
-        exclude_none = True
 
 class TouchDragAction(BaseModel):
     """
@@ -58,14 +50,6 @@ class TouchDragAction(BaseModel):
     endX: Length
     endY: Length
 
-    class Config:
-        """
-        Configuration for Pydantic model.
-        """
-        extra = json_extra_fields_policy
-        # Allow population of fields with default values
-        validate_assignment = True
-        exclude_none = True
 
 class TouchSwipeAction(BaseModel):
     """
@@ -77,15 +61,6 @@ class TouchSwipeAction(BaseModel):
     direction: Literal["up", "down", "left", "right"]
     distance: Length
 
-    class Config:
-        """
-        Configuration for Pydantic model.
-        """
-        extra = json_extra_fields_policy
-        # Allow population of fields with default values
-        validate_assignment = True
-        exclude_none = True
-
 class TouchLongPressAction(BaseModel):
     """
     Long press the screen at the specified coordinates.
@@ -94,12 +69,3 @@ class TouchLongPressAction(BaseModel):
     x: Length
     y: Length
     duration: int
-
-    class Config:
-        """
-        Configuration for Pydantic model.
-        """
-        extra = json_extra_fields_policy
-        # Allow population of fields with default values
-        validate_assignment = True
-        exclude_none = True

--- a/lybic/dto.py
+++ b/lybic/dto.py
@@ -28,7 +28,7 @@
 import uuid
 from enum import Enum, unique
 from typing import List, Optional, Literal
-from pydantic import BaseModel, Field, RootModel
+from pydantic import BaseModel, Field, RootModel, ConfigDict
 
 from lybic._api import deprecated
 
@@ -80,8 +80,8 @@ from lybic.action import (
     MobileUseAction,
     Action,
 )
-
-from lybic.action.common import json_extra_fields_policy
+# Strategy for handling extra fields in the lybic api response
+json_extra_fields_policy="ignore"
 
 class StatsResponseDto(BaseModel):
     """
@@ -117,7 +117,6 @@ class McpServerResponseDto(BaseModel):
     projectId: str = Field(..., description="Project ID to which the MCP server belongs.")
     policy: McpServerPolicy
     currentSandboxId: Optional[str] = Field(None, description="ID of the currently connected sandbox.")
-
 
 class ListMcpServerResponse(RootModel):
     """

--- a/lybic/dto.py
+++ b/lybic/dto.py
@@ -81,14 +81,7 @@ from lybic.action import (
     Action,
 )
 
-
-# Strategy for handling extra fields in the lybic api response
-# "ignore" means ignore extra fields, which will ensure that your SDK version remains compatible with the Lybic platform,
-# but it may cause compatibility issues with future versions of the SDK.
-# "forbid" means that the SDK will throw an error if it encounters extra fields in the response, which will force you to
-# update your SDK when the Lybic platform is updated, and may have a certain impact on your online environment.
-json_extra_fields_policy = "ignore"
-
+from lybic.action.common import json_extra_fields_policy
 
 class StatsResponseDto(BaseModel):
     """
@@ -97,11 +90,6 @@ class StatsResponseDto(BaseModel):
     mcpServers: int
     sandboxes: int
     projects: int
-    class Config:
-        """
-        Configuration for Pydantic model.
-        """
-        extra = json_extra_fields_policy
 
 
 class McpServerPolicy(BaseModel):
@@ -161,14 +149,6 @@ class CreateMcpServerDto(McpServerPolicy):
     sandboxExposeRestartTool: Optional[bool] = Field(False, description="Whether to expose restart tool to LLMs.")
     sandboxExposeDeleteTool: Optional[bool] = Field(False, description="Whether to expose delete tool to LLMs.")
 
-    class Config:
-        """
-        Configuration for Pydantic model.
-        """
-        extra = json_extra_fields_policy
-        # Allow population of fields with default values
-        validate_assignment = True
-
 class Shape(BaseModel):
     """
     Represents a shape of a sandbox.
@@ -195,11 +175,6 @@ class Sandbox(BaseModel):
     projectId: str = Field(..., description="Project ID to which the sandbox belongs.")
     shapeName: Optional[str] = Field(None, description="Specs and datacenter of the sandbox.") # This field does not exist in GetSandboxResponseDto (that is, this field is optional)
     shape: Optional[Shape] = None # This field does not exist in SandboxListResponseDto (that is, this field is optional)
-    class Config:
-        """
-        Configuration for Pydantic model.
-        """
-        extra = json_extra_fields_policy
 
 
 class GatewayAddress(BaseModel):
@@ -254,12 +229,6 @@ class CreateSandboxDto(BaseModel):
     projectId: Optional[str] = Field(None, description="The project id to use for the sandbox. Use default if not provided.")
     shape: str = Field(..., description="Specs and datacenter of the sandbox.")
 
-    class Config:
-        """
-        Configuration for Pydantic model.
-        """
-        exclude_none = True
-
 
 class GetSandboxResponseDto(BaseModel):
     """
@@ -287,15 +256,6 @@ class ComputerUseActionDto(BaseModel):
     includeCursorPosition: bool = True
     callId: Optional[str] = Field(default_factory=lambda: str(uuid.uuid4()))
 
-    class Config:
-        """
-        Configuration for Pydantic model.
-        """
-        extra = json_extra_fields_policy
-        # Allow population of fields with default values
-        validate_assignment = True
-        exclude_none = True
-
 
 class CursorPosition(BaseModel):
     """
@@ -306,11 +266,6 @@ class CursorPosition(BaseModel):
     screenWidth: int
     screenHeight: int
     screenIndex: int
-    class Config:
-        """
-        Configuration for Pydantic model.
-        """
-        extra = json_extra_fields_policy
 
 class ExtendSandboxDto(BaseModel):
     """
@@ -326,11 +281,6 @@ class SandboxActionResponseDto(BaseModel):
     screenShot: Optional[str] = None  # is a picture url of the screen eg. https://example.com/screen.webp
     cursorPosition: Optional[CursorPosition] = None
     actionResult: Optional[str] = None
-    class Config:
-        """
-        Configuration for Pydantic model.
-        """
-        extra = json_extra_fields_policy
 
 @unique
 class ModelType(Enum):
@@ -402,11 +352,7 @@ class ProjectResponseDto(BaseModel):
     name: str
     createdAt: str
     defaultProject: bool
-    class Config:
-        """
-        Configuration for Pydantic model.
-        """
-        extra = json_extra_fields_policy
+
 
 class ListProjectsResponseDto(RootModel):
     """
@@ -453,14 +399,7 @@ class Shapes(BaseModel):
     os: str
     virtualization:  str
     architecture:  str
-    class Config:
-        """
-        Configuration for Pydantic model.
-        """
-        extra = json_extra_fields_policy
-        # Allow population of fields with default values
-        validate_assignment = True
-        exclude_none = True
+
 
 class GetShapesResponseDto(RootModel):
     """
@@ -482,13 +421,8 @@ class MobileUseActionResponseDto(BaseModel):
     unknown: Optional[str] = None
     thoughts: Optional[str] = None
     memory: Optional[str] = None
-
     actions: List[MobileUseAction]
-    class Config:
-        """
-        Configuration for Pydantic model.
-        """
-        extra = json_extra_fields_policy
+
 
 
 # File Transfer Schemas
@@ -540,13 +474,6 @@ class FileCopyItem(BaseModel):
     id: Optional[str] = Field(None, description="A caller-defined unique identifier for this item. The value is included in the response to associate results with their corresponding requests")
     src: FileLocation = Field(..., description="Copy file source")
     dest: FileLocation = Field(..., description="Copy file destination")
-    class Config:
-        """
-        Configuration for Pydantic model.
-        """
-        exclude_none = True
-        extra = json_extra_fields_policy
-
 
 class SandboxFileCopyRequestDto(BaseModel):
     """
@@ -562,11 +489,6 @@ class FileCopyResult(BaseModel):
     id: Optional[str] = Field(None, description="Unique identifier of the files item from the request")
     success: bool = Field(..., description="Whether the operation succeeded")
     error: Optional[str] = Field(None, description="Error message if failed")
-    class Config:
-        """
-        Configuration for Pydantic model.
-        """
-        extra = json_extra_fields_policy
 
 
 class SandboxFileCopyResponseDto(BaseModel):
@@ -574,12 +496,6 @@ class SandboxFileCopyResponseDto(BaseModel):
     Response DTO for file copy operation.
     """
     results: List[FileCopyResult]
-    class Config:
-        """
-        Configuration for Pydantic model.
-        """
-        extra = json_extra_fields_policy
-
 
 # Process Execution Schemas
 class SandboxProcessRequestDto(BaseModel):
@@ -599,8 +515,3 @@ class SandboxProcessResponseDto(BaseModel):
     stdoutBase64: str = Field(default="", description="stdout as base64-encoded bytes")
     stderrBase64: str = Field(default="", description="stderr as base64-encoded bytes")
     exitCode: int = Field(..., description="Exit code")
-    class Config:
-        """
-        Configuration for Pydantic model.
-        """
-        extra = json_extra_fields_policy

--- a/lybic/dto.py
+++ b/lybic/dto.py
@@ -82,7 +82,7 @@ from lybic.action import (
     Action,
 )
 # Strategy for handling extra fields in the lybic api response
-json_extra_fields_policy:ExtraValues="ignore"
+json_extra_fields_policy: ExtraValues = "ignore"
 
 class StatsResponseDto(BaseModel):
     """

--- a/lybic/dto.py
+++ b/lybic/dto.py
@@ -28,7 +28,7 @@
 import uuid
 from enum import Enum, unique
 from typing import List, Optional, Literal
-from pydantic import BaseModel, Field, RootModel, ConfigDict
+from pydantic import BaseModel, Field, RootModel
 
 from lybic._api import deprecated
 

--- a/lybic/dto.py
+++ b/lybic/dto.py
@@ -128,8 +128,6 @@ class ListMcpServerResponse(RootModel):
     """
     A list of MCP server responses.
     """
-    model_config = ConfigDict(extra=json_extra_fields_policy)
-
     root: List[McpServerResponseDto]
 
     def __iter__(self):
@@ -224,8 +222,6 @@ class SandboxListResponseDto(RootModel):
     """
     A response DTO containing a list of sandboxes.
     """
-    model_config = ConfigDict(extra=json_extra_fields_policy)
-
     root: List[SandboxListItem]
 
     def __iter__(self):
@@ -441,8 +437,6 @@ class GetShapesResponseDto(RootModel):
     """
     Response DTO for getting shapers.
     """
-    model_config = ConfigDict(extra=json_extra_fields_policy)
-
     root: List[Shapes]
 
     def __iter__(self):

--- a/lybic/dto.py
+++ b/lybic/dto.py
@@ -28,7 +28,8 @@
 import uuid
 from enum import Enum, unique
 from typing import List, Optional, Literal
-from pydantic import BaseModel, Field, RootModel
+from pydantic import BaseModel, Field, RootModel, ConfigDict
+from pydantic.config import ExtraValues
 
 from lybic._api import deprecated
 
@@ -81,12 +82,13 @@ from lybic.action import (
     Action,
 )
 # Strategy for handling extra fields in the lybic api response
-json_extra_fields_policy="ignore"
+json_extra_fields_policy:ExtraValues="ignore"
 
 class StatsResponseDto(BaseModel):
     """
     Organization Stats response.
     """
+    model_config = ConfigDict(extra=json_extra_fields_policy,validate_assignment=True)
     mcpServers: int
     sandboxes: int
     projects: int
@@ -96,6 +98,8 @@ class McpServerPolicy(BaseModel):
     """
     MCP server sandbox policy.
     """
+    model_config = ConfigDict(extra=json_extra_fields_policy)
+
     sandboxShape: str = Field('', description="The shape of the sandbox created by the MCP server.")
     sandboxMaxLifetimeSeconds: int = Field(3600, description="The maximum lifetime of a sandbox.")
     sandboxMaxIdleTimeSeconds: int = Field(3600, description="The maximum idle time of a sandbox.")
@@ -110,6 +114,8 @@ class McpServerResponseDto(BaseModel):
     """
     MCP server response.
     """
+    model_config = ConfigDict(extra=json_extra_fields_policy)
+
     id: str = Field(..., description="ID of the MCP server.")
     name: str = Field(..., description="Name of the MCP server.")
     createdAt: str = Field(..., description="Creation date of the MCP server.")
@@ -122,6 +128,8 @@ class ListMcpServerResponse(RootModel):
     """
     A list of MCP server responses.
     """
+    model_config = ConfigDict(extra=json_extra_fields_policy)
+
     root: List[McpServerResponseDto]
 
     def __iter__(self):
@@ -152,6 +160,8 @@ class Shape(BaseModel):
     """
     Represents a shape of a sandbox.
     """
+    model_config = ConfigDict(extra=json_extra_fields_policy)
+
     name: str = Field(..., description="Name of the shape.")
     description: str = Field(..., description="Description of the shape.")
     hardwareAcceleratedEncoding: bool = Field(False, description="Whether the shape supports hardware accelerated encoding.")
@@ -166,6 +176,8 @@ class Sandbox(BaseModel):
     """
     Represents a sandbox environment.
     """
+    model_config = ConfigDict(extra=json_extra_fields_policy)
+
     id: str = Field(..., description="ID of the sandbox.")
     name: str = Field(..., description="Name of the sandbox.")
     expiredAt: str = Field(..., description="Deprecated, use `expiresAt` instead, will be removed in v1.0.0")
@@ -180,6 +192,8 @@ class GatewayAddress(BaseModel):
     """
     Details of a gateway address for connecting to a sandbox.
     """
+    model_config = ConfigDict(extra=json_extra_fields_policy)
+
     address: str
     port: int
     name: str
@@ -192,6 +206,8 @@ class ConnectDetails(BaseModel):
     """
     Connection details for a sandbox, including gateway addresses and authentication tokens.
     """
+    model_config = ConfigDict(extra=json_extra_fields_policy)
+
     gatewayAddresses: List[GatewayAddress]
     certificateHashBase64: str
     endUserToken: str
@@ -208,6 +224,8 @@ class SandboxListResponseDto(RootModel):
     """
     A response DTO containing a list of sandboxes.
     """
+    model_config = ConfigDict(extra=json_extra_fields_policy)
+
     root: List[SandboxListItem]
 
     def __iter__(self):
@@ -221,6 +239,8 @@ class CreateSandboxDto(BaseModel):
     """
     Create sandbox request.
     """
+    model_config = ConfigDict(extra=json_extra_fields_policy)
+
     name: str = Field("sandbox", description="The name of the sandbox.")
     maxLifeSeconds: int = Field(3600,
                                 description="The maximum life time of the sandbox in seconds. Default is 1 hour, max is 1 day.",
@@ -233,6 +253,8 @@ class GetSandboxResponseDto(BaseModel):
     """
     A response DTO for a single sandbox, including connection details.
     """
+    model_config = ConfigDict(extra=json_extra_fields_policy)
+
     sandbox: Sandbox
     connectDetails: ConnectDetails
 
@@ -250,6 +272,8 @@ class ComputerUseActionDto(BaseModel):
     """
     Computer use action request.
     """
+    model_config = ConfigDict(extra=json_extra_fields_policy)
+
     action: ComputerUseAction | dict
     includeScreenShot: bool = True
     includeCursorPosition: bool = True
@@ -277,6 +301,8 @@ class SandboxActionResponseDto(BaseModel):
     """
     Computer use action response.
     """
+    model_config = ConfigDict(extra=json_extra_fields_policy)
+
     screenShot: Optional[str] = None  # is a picture url of the screen eg. https://example.com/screen.webp
     cursorPosition: Optional[CursorPosition] = None
     actionResult: Optional[str] = None
@@ -321,6 +347,8 @@ class ComputerUseActionResponseDto(BaseModel):
     """
     Response DTO containing a list of parsed computer use actions.
     """
+    model_config = ConfigDict(extra=json_extra_fields_policy)
+
     unknown: Optional[str] = None
     thoughts: Optional[str] = None
     memory: Optional[str] = None
@@ -336,6 +364,8 @@ class ExecuteSandboxActionDto(BaseModel):
     """
     Sandbox action request, supporting both computer and mobile use actions.
     """
+    model_config = ConfigDict(extra=json_extra_fields_policy)
+
     action: Action | dict
     includeScreenShot: bool = True
     includeCursorPosition: bool = True
@@ -347,6 +377,8 @@ class ProjectResponseDto(BaseModel):
     """
     Get Project Response
     """
+    model_config = ConfigDict(extra=json_extra_fields_policy)
+
     id: str
     name: str
     createdAt: str
@@ -377,12 +409,15 @@ class SingleProjectResponseDto(ProjectResponseDto):
     """
     Response DTO for a single project.
     """
+    model_config = ConfigDict(extra=json_extra_fields_policy)
 
 
 class SetMcpServerToSandboxResponseDto(BaseModel):
     """
     Response DTO for setting a MCP server to a sandbox.
     """
+    model_config = ConfigDict(extra=json_extra_fields_policy)
+
     sandboxId: Optional[str] = Field(None, description="The ID of the sandbox to connect the MCP server to.")
 
 
@@ -390,6 +425,8 @@ class Shapes(BaseModel):
     """
     Shapes
     """
+    model_config = ConfigDict(extra=json_extra_fields_policy)
+
     name: str
     description: str
     hardwareAcceleratedEncoding: bool
@@ -404,6 +441,8 @@ class GetShapesResponseDto(RootModel):
     """
     Response DTO for getting shapers.
     """
+    model_config = ConfigDict(extra=json_extra_fields_policy)
+
     root: List[Shapes]
 
     def __iter__(self):
@@ -417,6 +456,8 @@ class MobileUseActionResponseDto(BaseModel):
     """
     Response DTO containing a list of parsed mobile use actions.
     """
+    model_config = ConfigDict(extra=json_extra_fields_policy)
+
     unknown: Optional[str] = None
     thoughts: Optional[str] = None
     memory: Optional[str] = None
@@ -494,6 +535,8 @@ class SandboxFileCopyResponseDto(BaseModel):
     """
     Response DTO for file copy operation.
     """
+    model_config = ConfigDict(extra=json_extra_fields_policy)
+
     results: List[FileCopyResult]
 
 # Process Execution Schemas
@@ -511,6 +554,8 @@ class SandboxProcessResponseDto(BaseModel):
     """
     Response DTO for process execution.
     """
+    model_config = ConfigDict(extra=json_extra_fields_policy)
+
     stdoutBase64: str = Field(default="", description="stdout as base64-encoded bytes")
     stderrBase64: str = Field(default="", description="stderr as base64-encoded bytes")
     exitCode: int = Field(..., description="Exit code")

--- a/lybic/mcp.py
+++ b/lybic/mcp.py
@@ -33,7 +33,6 @@ import httpx
 from lybic import dto
 from lybic._api import deprecated
 from lybic.lybic import LybicClient
-from lybic.dto import json_extra_fields_policy
 
 # pylint: disable=invalid-name
 try:
@@ -68,7 +67,7 @@ class Mcp:
             "GET",
             f"/api/orgs/{self.client.org_id}/mcp-servers")
         self.client.logger.debug(f"List MCP servers response: {response.text}")
-        return dto.ListMcpServerResponse.model_validate_json(response.text,strict=json_extra_fields_policy=='forbid')
+        return dto.ListMcpServerResponse.model_validate_json(response.text)
 
     @overload
     async def create(self, data: dto.CreateMcpServerDto) -> dto.McpServerResponseDto: ...
@@ -95,7 +94,7 @@ class Mcp:
             f"/api/orgs/{self.client.org_id}/mcp-servers",
             json=data.model_dump(exclude_none=True))
         self.client.logger.debug(f"Create MCP server response: {response.text}")
-        return dto.McpServerResponseDto.model_validate_json(response.text,strict=json_extra_fields_policy=='forbid')
+        return dto.McpServerResponseDto.model_validate_json(response.text)
 
     async def get_default(self) -> dto.McpServerResponseDto:
         """
@@ -108,7 +107,7 @@ class Mcp:
             "GET",
             f"/api/orgs/{self.client.org_id}/mcp-servers/default")
         self.client.logger.debug(f"Get default MCP server response: {response.text}")
-        return dto.McpServerResponseDto.model_validate_json(response.text,strict=json_extra_fields_policy=='forbid')
+        return dto.McpServerResponseDto.model_validate_json(response.text)
 
     async def delete(self, mcp_server_id: str) -> None:
         """

--- a/lybic/mcp.py
+++ b/lybic/mcp.py
@@ -33,6 +33,7 @@ import httpx
 from lybic import dto
 from lybic._api import deprecated
 from lybic.lybic import LybicClient
+from lybic.dto import json_extra_fields_policy
 
 # pylint: disable=invalid-name
 try:
@@ -67,7 +68,7 @@ class Mcp:
             "GET",
             f"/api/orgs/{self.client.org_id}/mcp-servers")
         self.client.logger.debug(f"List MCP servers response: {response.text}")
-        return dto.ListMcpServerResponse.model_validate_json(response.text)
+        return dto.ListMcpServerResponse.model_validate_json(response.text,strict=json_extra_fields_policy=='forbid')
 
     @overload
     async def create(self, data: dto.CreateMcpServerDto) -> dto.McpServerResponseDto: ...
@@ -88,13 +89,13 @@ class Mcp:
             data = kwargs["data"]
         else:
             data = dto.CreateMcpServerDto(**kwargs)
-        self.client.logger.debug(f"Create MCP server request: {data.model_dump_json()}")
+        self.client.logger.debug(f"Create MCP server request: {data.model_dump_json(exclude_none=True)}")
         response = await self.client.request(
             "POST",
             f"/api/orgs/{self.client.org_id}/mcp-servers",
-            json=data.model_dump())
+            json=data.model_dump(exclude_none=True))
         self.client.logger.debug(f"Create MCP server response: {response.text}")
-        return dto.McpServerResponseDto.model_validate_json(response.text)
+        return dto.McpServerResponseDto.model_validate_json(response.text,strict=json_extra_fields_policy=='forbid')
 
     async def get_default(self) -> dto.McpServerResponseDto:
         """
@@ -107,7 +108,7 @@ class Mcp:
             "GET",
             f"/api/orgs/{self.client.org_id}/mcp-servers/default")
         self.client.logger.debug(f"Get default MCP server response: {response.text}")
-        return dto.McpServerResponseDto.model_validate_json(response.text)
+        return dto.McpServerResponseDto.model_validate_json(response.text,strict=json_extra_fields_policy=='forbid')
 
     async def delete(self, mcp_server_id: str) -> None:
         """
@@ -128,11 +129,11 @@ class Mcp:
         :return: None
         """
         data = dto.SetMcpServerToSandboxResponseDto(sandboxId=sandbox_id)
-        self.client.logger.debug(f"Set MCP server to sandbox request: {data.model_dump_json()}")
+        self.client.logger.debug(f"Set MCP server to sandbox request: {data.model_dump_json(exclude_none=True)}")
         await self.client.request(
             "POST",
             f"/api/orgs/{self.client.org_id}/mcp-servers/{mcp_server_id}/sandbox",
-            json=data.model_dump())
+            json=data.model_dump(exclude_none=True))
 
     async def call_tool_async(self,
                               mcp_server_id: str,
@@ -182,7 +183,7 @@ class Mcp:
 @deprecated(
     since="0.8.0",
     removal="1.0.0",
-    message="Use Mcp instead"
+    message="renamed: Use Mcp instead"
 )
 class MCP(Mcp):
     """

--- a/lybic/project.py
+++ b/lybic/project.py
@@ -29,7 +29,6 @@ from typing import overload
 
 from lybic import dto
 from lybic.lybic import LybicClient
-from lybic.dto import json_extra_fields_policy
 
 class Project:
     """
@@ -45,7 +44,7 @@ class Project:
         self.client.logger.debug("Listing projects request")
         response = await self.client.request("GET", f"/api/orgs/{self.client.org_id}/projects")
         self.client.logger.debug("Listing projects response: %s", response.text)
-        return dto.ListProjectsResponseDto.model_validate_json(response.text,strict=json_extra_fields_policy=='forbid')
+        return dto.ListProjectsResponseDto.model_validate_json(response.text)
 
     @overload
     async def create(self, data: dto.CreateProjectDto) -> dto.SingleProjectResponseDto: ...
@@ -66,7 +65,7 @@ class Project:
             "POST",
             f"/api/orgs/{self.client.org_id}/projects", json=data.model_dump(exclude_none=True))
         self.client.logger.debug("Create project response: %s", response.text)
-        return dto.SingleProjectResponseDto.model_validate_json(response.text,strict=json_extra_fields_policy=='forbid')
+        return dto.SingleProjectResponseDto.model_validate_json(response.text)
 
     async def delete(self, project_id: str) -> None:
         """

--- a/lybic/project.py
+++ b/lybic/project.py
@@ -29,6 +29,7 @@ from typing import overload
 
 from lybic import dto
 from lybic.lybic import LybicClient
+from lybic.dto import json_extra_fields_policy
 
 class Project:
     """
@@ -44,7 +45,7 @@ class Project:
         self.client.logger.debug("Listing projects request")
         response = await self.client.request("GET", f"/api/orgs/{self.client.org_id}/projects")
         self.client.logger.debug("Listing projects response: %s", response.text)
-        return dto.ListProjectsResponseDto.model_validate_json(response.text)
+        return dto.ListProjectsResponseDto.model_validate_json(response.text,strict=json_extra_fields_policy=='forbid')
 
     @overload
     async def create(self, data: dto.CreateProjectDto) -> dto.SingleProjectResponseDto: ...
@@ -63,9 +64,9 @@ class Project:
         self.client.logger.debug("Creating project request with data: %s", data)
         response = await self.client.request(
             "POST",
-            f"/api/orgs/{self.client.org_id}/projects", json=data.model_dump())
+            f"/api/orgs/{self.client.org_id}/projects", json=data.model_dump(exclude_none=True))
         self.client.logger.debug("Create project response: %s", response.text)
-        return dto.SingleProjectResponseDto.model_validate_json(response.text)
+        return dto.SingleProjectResponseDto.model_validate_json(response.text,strict=json_extra_fields_policy=='forbid')
 
     async def delete(self, project_id: str) -> None:
         """

--- a/lybic/sandbox.py
+++ b/lybic/sandbox.py
@@ -39,7 +39,6 @@ from PIL.WebPImagePlugin import WebPImageFile
 from lybic import dto
 from lybic._api import deprecated
 from lybic.lybic import LybicClient
-from lybic.dto import json_extra_fields_policy
 
 class Sandbox:
     """
@@ -55,7 +54,7 @@ class Sandbox:
         self.client.logger.debug("Listing sandboxes requests")
         response = await self.client.request("GET", f"/api/orgs/{self.client.org_id}/sandboxes")
         self.client.logger.debug(f"Listing sandboxes response: {response.text}")
-        return dto.SandboxListResponseDto.model_validate_json(response.text,strict=json_extra_fields_policy=='forbid')
+        return dto.SandboxListResponseDto.model_validate_json(response.text)
 
     @overload
     async def create(self, data: dto.CreateSandboxDto) -> dto.Sandbox: ...
@@ -78,7 +77,7 @@ class Sandbox:
             "POST",
             f"/api/orgs/{self.client.org_id}/sandboxes", json=data.model_dump(exclude_none=True))
         self.client.logger.debug(f"Create sandbox response: {response.text}")
-        return dto.Sandbox.model_validate_json(response.text,strict=json_extra_fields_policy=='forbid')
+        return dto.Sandbox.model_validate_json(response.text)
 
     async def get(self, sandbox_id: str) -> dto.GetSandboxResponseDto:
         """
@@ -89,7 +88,7 @@ class Sandbox:
             "GET",
             f"/api/orgs/{self.client.org_id}/sandboxes/{sandbox_id}")
         self.client.logger.debug(f"Get sandbox response: {response.text}")
-        return dto.GetSandboxResponseDto.model_validate_json(response.text,strict=json_extra_fields_policy=='forbid')
+        return dto.GetSandboxResponseDto.model_validate_json(response.text)
 
     async def delete(self, sandbox_id: str) -> None:
         """
@@ -150,7 +149,7 @@ class Sandbox:
                                        f"/api/orgs/{self.client.org_id}/sandboxes/{sandbox_id}/actions/computer-use",
                                        json=data.model_dump(exclude_none=True))
         self.client.logger.debug(f"Execute computer use action response: {response.text}")
-        return dto.SandboxActionResponseDto.model_validate_json(response.text,strict=json_extra_fields_policy=='forbid')
+        return dto.SandboxActionResponseDto.model_validate_json(response.text)
 
     async def preview(self, sandbox_id: str) -> dto.SandboxActionResponseDto:
         """
@@ -161,7 +160,7 @@ class Sandbox:
             "POST",
             f"/api/orgs/{self.client.org_id}/sandboxes/{sandbox_id}/preview")
         self.client.logger.debug(f"Previewed sandbox {sandbox_id}")
-        return dto.SandboxActionResponseDto.model_validate_json(response.text,strict=json_extra_fields_policy=='forbid')
+        return dto.SandboxActionResponseDto.model_validate_json(response.text)
 
     async def extend_life(self, sandbox_id: str, seconds: int = 3600) -> None:
         """Extend the life of a sandbox.
@@ -234,7 +233,7 @@ class Sandbox:
             f"/api/orgs/{self.client.org_id}/shapes"
         )
         self.client.logger.debug(f"Get shapes response: {response.text}")
-        return dto.GetShapesResponseDto.model_validate_json(response.text,strict=json_extra_fields_policy=='forbid')
+        return dto.GetShapesResponseDto.model_validate_json(response.text)
 
     @overload
     async def execute_sandbox_action(self, sandbox_id: str, data: dto.ExecuteSandboxActionDto) -> dto.SandboxActionResponseDto: ...
@@ -264,7 +263,7 @@ class Sandbox:
                                              f"/api/orgs/{self.client.org_id}/sandboxes/{sandbox_id}/actions/execute",
                                              json=data.model_dump(exclude_none=True))
         self.client.logger.debug(f"Execute sandbox action response: {response.text}")
-        return dto.SandboxActionResponseDto.model_validate_json(response.text,strict=json_extra_fields_policy=='forbid')
+        return dto.SandboxActionResponseDto.model_validate_json(response.text)
 
     @overload
     async def copy_files(self, sandbox_id: str, data: dto.SandboxFileCopyRequestDto) -> dto.SandboxFileCopyResponseDto: ...
@@ -294,7 +293,7 @@ class Sandbox:
             f"/api/orgs/{self.client.org_id}/sandboxes/{sandbox_id}/file/copy",
             json=data.model_dump(exclude_none=True))
         self.client.logger.debug(f"Copy files response: {response.text}")
-        return dto.SandboxFileCopyResponseDto.model_validate_json(response.text,strict=json_extra_fields_policy=='forbid')
+        return dto.SandboxFileCopyResponseDto.model_validate_json(response.text)
 
     @overload
     async def execute_process(self, sandbox_id: str, data: dto.SandboxProcessRequestDto) -> dto.SandboxProcessResponseDto: ...
@@ -324,4 +323,4 @@ class Sandbox:
             f"/api/orgs/{self.client.org_id}/sandboxes/{sandbox_id}/process",
             json=data.model_dump(exclude_none=True))
         self.client.logger.debug(f"Execute process response: {response.text}")
-        return dto.SandboxProcessResponseDto.model_validate_json(response.text,strict=json_extra_fields_policy=='forbid')
+        return dto.SandboxProcessResponseDto.model_validate_json(response.text)

--- a/lybic/sandbox.py
+++ b/lybic/sandbox.py
@@ -39,6 +39,7 @@ from PIL.WebPImagePlugin import WebPImageFile
 from lybic import dto
 from lybic._api import deprecated
 from lybic.lybic import LybicClient
+from lybic.dto import json_extra_fields_policy
 
 class Sandbox:
     """
@@ -54,7 +55,7 @@ class Sandbox:
         self.client.logger.debug("Listing sandboxes requests")
         response = await self.client.request("GET", f"/api/orgs/{self.client.org_id}/sandboxes")
         self.client.logger.debug(f"Listing sandboxes response: {response.text}")
-        return dto.SandboxListResponseDto.model_validate_json(response.text)
+        return dto.SandboxListResponseDto.model_validate_json(response.text,strict=json_extra_fields_policy=='forbid')
 
     @overload
     async def create(self, data: dto.CreateSandboxDto) -> dto.Sandbox: ...
@@ -77,7 +78,7 @@ class Sandbox:
             "POST",
             f"/api/orgs/{self.client.org_id}/sandboxes", json=data.model_dump(exclude_none=True))
         self.client.logger.debug(f"Create sandbox response: {response.text}")
-        return dto.Sandbox.model_validate_json(response.text)
+        return dto.Sandbox.model_validate_json(response.text,strict=json_extra_fields_policy=='forbid')
 
     async def get(self, sandbox_id: str) -> dto.GetSandboxResponseDto:
         """
@@ -88,7 +89,7 @@ class Sandbox:
             "GET",
             f"/api/orgs/{self.client.org_id}/sandboxes/{sandbox_id}")
         self.client.logger.debug(f"Get sandbox response: {response.text}")
-        return dto.GetSandboxResponseDto.model_validate_json(response.text)
+        return dto.GetSandboxResponseDto.model_validate_json(response.text,strict=json_extra_fields_policy=='forbid')
 
     async def delete(self, sandbox_id: str) -> None:
         """
@@ -144,12 +145,12 @@ class Sandbox:
                 raise TypeError(f"The 'data' argument must be of type {dto.ComputerUseActionDto.__name__} or dict")
         else:
             data = dto.ComputerUseActionDto(**kwargs)
-        self.client.logger.debug(f"Execute computer use action request: {data.model_dump_json()}")
+        self.client.logger.debug(f"Execute computer use action request: {data.model_dump_json(exclude_none=True)}")
         response = await self.client.request("POST",
                                        f"/api/orgs/{self.client.org_id}/sandboxes/{sandbox_id}/actions/computer-use",
                                        json=data.model_dump(exclude_none=True))
         self.client.logger.debug(f"Execute computer use action response: {response.text}")
-        return dto.SandboxActionResponseDto.model_validate_json(response.text)
+        return dto.SandboxActionResponseDto.model_validate_json(response.text,strict=json_extra_fields_policy=='forbid')
 
     async def preview(self, sandbox_id: str) -> dto.SandboxActionResponseDto:
         """
@@ -160,7 +161,7 @@ class Sandbox:
             "POST",
             f"/api/orgs/{self.client.org_id}/sandboxes/{sandbox_id}/preview")
         self.client.logger.debug(f"Previewed sandbox {sandbox_id}")
-        return dto.SandboxActionResponseDto.model_validate_json(response.text)
+        return dto.SandboxActionResponseDto.model_validate_json(response.text,strict=json_extra_fields_policy=='forbid')
 
     async def extend_life(self, sandbox_id: str, seconds: int = 3600) -> None:
         """Extend the life of a sandbox.
@@ -178,11 +179,11 @@ class Sandbox:
         await self.client.request(
             "POST",
             f"/api/orgs/{self.client.org_id}/sandboxes/{sandbox_id}/extend",
-            json=data.model_dump())
+            json=data.model_dump(exclude_none=True))
 
     async def get_connection_details(self, sandbox_id: str)-> dto.ConnectDetails:
         """
-        Get connection details for a sandbox
+        Get stream connection details for a sandbox
         """
         sandbox = await self.get(sandbox_id)
         return sandbox.connectDetails
@@ -233,7 +234,7 @@ class Sandbox:
             f"/api/orgs/{self.client.org_id}/shapes"
         )
         self.client.logger.debug(f"Get shapes response: {response.text}")
-        return dto.GetShapesResponseDto.model_validate_json(response.text)
+        return dto.GetShapesResponseDto.model_validate_json(response.text,strict=json_extra_fields_policy=='forbid')
 
     @overload
     async def execute_sandbox_action(self, sandbox_id: str, data: dto.ExecuteSandboxActionDto) -> dto.SandboxActionResponseDto: ...
@@ -263,7 +264,7 @@ class Sandbox:
                                              f"/api/orgs/{self.client.org_id}/sandboxes/{sandbox_id}/actions/execute",
                                              json=data.model_dump(exclude_none=True))
         self.client.logger.debug(f"Execute sandbox action response: {response.text}")
-        return dto.SandboxActionResponseDto.model_validate_json(response.text)
+        return dto.SandboxActionResponseDto.model_validate_json(response.text,strict=json_extra_fields_policy=='forbid')
 
     @overload
     async def copy_files(self, sandbox_id: str, data: dto.SandboxFileCopyRequestDto) -> dto.SandboxFileCopyResponseDto: ...
@@ -293,7 +294,7 @@ class Sandbox:
             f"/api/orgs/{self.client.org_id}/sandboxes/{sandbox_id}/file/copy",
             json=data.model_dump(exclude_none=True))
         self.client.logger.debug(f"Copy files response: {response.text}")
-        return dto.SandboxFileCopyResponseDto.model_validate_json(response.text)
+        return dto.SandboxFileCopyResponseDto.model_validate_json(response.text,strict=json_extra_fields_policy=='forbid')
 
     @overload
     async def execute_process(self, sandbox_id: str, data: dto.SandboxProcessRequestDto) -> dto.SandboxProcessResponseDto: ...
@@ -323,4 +324,4 @@ class Sandbox:
             f"/api/orgs/{self.client.org_id}/sandboxes/{sandbox_id}/process",
             json=data.model_dump(exclude_none=True))
         self.client.logger.debug(f"Execute process response: {response.text}")
-        return dto.SandboxProcessResponseDto.model_validate_json(response.text)
+        return dto.SandboxProcessResponseDto.model_validate_json(response.text,strict=json_extra_fields_policy=='forbid')

--- a/lybic/stats.py
+++ b/lybic/stats.py
@@ -27,6 +27,7 @@
 """Provides the Stats class for accessing organization statistics."""
 from lybic import dto
 from lybic.lybic import LybicClient
+from lybic.dto import json_extra_fields_policy
 
 class Stats:
     """Provides methods to retrieve statistics for an organization."""
@@ -40,4 +41,4 @@ class Stats:
         self.client.logger.debug("Get stats requests")
         response = await self.client.request("GET", f"/api/orgs/{self.client.org_id}/stats")
         self.client.logger.debug("Get stats response: %s", response.text)
-        return dto.StatsResponseDto.model_validate_json(response.text)
+        return dto.StatsResponseDto.model_validate_json(response.text,strict=json_extra_fields_policy=='forbid')

--- a/lybic/stats.py
+++ b/lybic/stats.py
@@ -27,7 +27,6 @@
 """Provides the Stats class for accessing organization statistics."""
 from lybic import dto
 from lybic.lybic import LybicClient
-from lybic.dto import json_extra_fields_policy
 
 class Stats:
     """Provides methods to retrieve statistics for an organization."""
@@ -41,4 +40,4 @@ class Stats:
         self.client.logger.debug("Get stats requests")
         response = await self.client.request("GET", f"/api/orgs/{self.client.org_id}/stats")
         self.client.logger.debug("Get stats response: %s", response.text)
-        return dto.StatsResponseDto.model_validate_json(response.text,strict=json_extra_fields_policy=='forbid')
+        return dto.StatsResponseDto.model_validate_json(response.text)

--- a/lybic/tools.py
+++ b/lybic/tools.py
@@ -38,8 +38,6 @@ from lybic.dto import (
     ComputerUseActionDto,
     SandboxActionResponseDto,
     MobileUseActionResponseDto,
-
-    json_extra_fields_policy
 )
 from lybic.lybic import LybicClient
 from lybic._api import deprecated
@@ -86,7 +84,7 @@ class ComputerUse:
             "/api/computer-use/parse",
             json=data.model_dump(exclude_none=True))
         self.client.logger.debug(f"Parse model output response: {response.text}")
-        return ComputerUseActionResponseDto.model_validate_json(response.text,strict=json_extra_fields_policy=='forbid')
+        return ComputerUseActionResponseDto.model_validate_json(response.text)
     async def parse_llm_output(
         self, model_type: ModelType | str, llm_output: str
     ) -> ComputerUseActionResponseDto:
@@ -115,7 +113,7 @@ class ComputerUse:
             json=ParseTextRequestDto(textContent=llm_output).model_dump(exclude_none=True),
         )
         self.client.logger.debug(f"Parse model output response: {response.text}")
-        return ComputerUseActionResponseDto.model_validate_json(response.text,strict=json_extra_fields_policy=='forbid')
+        return ComputerUseActionResponseDto.model_validate_json(response.text)
 
     @deprecated(
         since="0.8.0",
@@ -173,7 +171,7 @@ class ComputerUse:
                                        f"/api/orgs/{self.client.org_id}/sandboxes/{sandbox_id}/actions/computer-use",
                                        json=data.model_dump(exclude_none=True))
         self.client.logger.debug(f"Execute computer use action response: {response.text}")
-        return SandboxActionResponseDto.model_validate_json(response.text,strict=json_extra_fields_policy=='forbid')
+        return SandboxActionResponseDto.model_validate_json(response.text)
 
 class MobileUse:
     """MobileUse is an async client for lybic MobileUse API(MCP and Restful)."""
@@ -208,4 +206,4 @@ class MobileUse:
             json=ParseTextRequestDto(textContent=llm_output).model_dump(exclude_none=True),
         )
         self.client.logger.debug(f"Parse model output response: {response.text}")
-        return MobileUseActionResponseDto.model_validate_json(response.text,strict=json_extra_fields_policy=='forbid')
+        return MobileUseActionResponseDto.model_validate_json(response.text)

--- a/lybic/tools.py
+++ b/lybic/tools.py
@@ -37,7 +37,9 @@ from lybic.dto import (
     ModelType,
     ComputerUseActionDto,
     SandboxActionResponseDto,
-    MobileUseActionResponseDto
+    MobileUseActionResponseDto,
+
+    json_extra_fields_policy
 )
 from lybic.lybic import LybicClient
 from lybic._api import deprecated
@@ -78,13 +80,13 @@ class ComputerUse:
             data = kwargs["data"]
         else:
             data = ComputerUseParseRequestDto(**kwargs)
-        self.client.logger.debug(f"Parse model output request: {data.model_dump_json()}")
+        self.client.logger.debug(f"Parse model output request: {data.model_dump_json(exclude_none=True)}")
         response = await self.client.request(
             "POST",
             "/api/computer-use/parse",
             json=data.model_dump(exclude_none=True))
         self.client.logger.debug(f"Parse model output response: {response.text}")
-        return ComputerUseActionResponseDto.model_validate_json(response.text)
+        return ComputerUseActionResponseDto.model_validate_json(response.text,strict=json_extra_fields_policy=='forbid')
     async def parse_llm_output(
         self, model_type: ModelType | str, llm_output: str
     ) -> ComputerUseActionResponseDto:
@@ -110,10 +112,10 @@ class ComputerUse:
         response = await self.client.request(
             "POST",
             f"/api/computer-use/parse/{model}",
-            json=ParseTextRequestDto(textContent=llm_output).model_dump(),
+            json=ParseTextRequestDto(textContent=llm_output).model_dump(exclude_none=True),
         )
         self.client.logger.debug(f"Parse model output response: {response.text}")
-        return ComputerUseActionResponseDto.model_validate_json(response.text)
+        return ComputerUseActionResponseDto.model_validate_json(response.text,strict=json_extra_fields_policy=='forbid')
 
     @deprecated(
         since="0.8.0",
@@ -166,12 +168,12 @@ class ComputerUse:
                 raise TypeError(f"The 'data' argument must be of type {ComputerUseActionDto.__name__} or dict")
         else:
             data = ComputerUseActionDto(**kwargs)
-        self.client.logger.debug(f"Execute computer use action request: {data.model_dump_json()}")
+        self.client.logger.debug(f"Execute computer use action request: {data.model_dump_json(exclude_none=True)}")
         response = await self.client.request("POST",
                                        f"/api/orgs/{self.client.org_id}/sandboxes/{sandbox_id}/actions/computer-use",
                                        json=data.model_dump(exclude_none=True))
         self.client.logger.debug(f"Execute computer use action response: {response.text}")
-        return SandboxActionResponseDto.model_validate_json(response.text)
+        return SandboxActionResponseDto.model_validate_json(response.text,strict=json_extra_fields_policy=='forbid')
 
 class MobileUse:
     """MobileUse is an async client for lybic MobileUse API(MCP and Restful)."""
@@ -203,7 +205,7 @@ class MobileUse:
         response = await self.client.request(
             "POST",
             f"/api/mobile-use/parse/{model}",
-            json=ParseTextRequestDto(textContent=llm_output).model_dump(),
+            json=ParseTextRequestDto(textContent=llm_output).model_dump(exclude_none=True),
         )
         self.client.logger.debug(f"Parse model output response: {response.text}")
-        return MobileUseActionResponseDto.model_validate_json(response.text)
+        return MobileUseActionResponseDto.model_validate_json(response.text,strict=json_extra_fields_policy=='forbid')


### PR DESCRIPTION
#### What this PR does / why we need it? Summary of your change
This pull request refactors how the handling of extra fields in Lybic API responses is configured and simplifies the codebase by removing repetitive Pydantic `Config` definitions from various model classes. The strategy for extra fields (`json_extra_fields_policy`) is now imported and exposed at the package level, but the explicit use of this policy in individual model configs has been removed throughout the codebase. This makes the models cleaner and centralizes the configuration.

**Configuration and API response handling:**

* The `json_extra_fields_policy` is now imported and exposed in `lybic/__init__.py`, making it available as part of the public API for easier configuration and documentation. [[1]](diffhunk://#diff-6d7740cee3fe8c11c5a71120f01a6b0cd25d5050c0f3f023cface79d51fb7404R31-R37) [[2]](diffhunk://#diff-6d7740cee3fe8c11c5a71120f01a6b0cd25d5050c0f3f023cface79d51fb7404R71-R72)
* The definition of `json_extra_fields_policy` was moved from `lybic/dto.py` to `lybic/action/common.py` for better organization and single-source-of-truth.

**Codebase simplification:**

* All Pydantic model classes in `lybic/action/common.py`, `lybic/action/android.py`, `lybic/action/computer.py`, `lybic/action/os.py`, and `lybic/action/touch.py` had their explicit `Config` inner classes removed, eliminating repetitive configuration and reducing boilerplate. [[1]](diffhunk://#diff-45033f0af51b02f3d77fd715382eaad0941e66d2655be1a80ad2cbe521ff17eeL44-L51) [[2]](diffhunk://#diff-45033f0af51b02f3d77fd715382eaad0941e66d2655be1a80ad2cbe521ff17eeL61-L69) [[3]](diffhunk://#diff-45033f0af51b02f3d77fd715382eaad0941e66d2655be1a80ad2cbe521ff17eeL79-L103) [[4]](diffhunk://#diff-45033f0af51b02f3d77fd715382eaad0941e66d2655be1a80ad2cbe521ff17eeL112-L120) [[5]](diffhunk://#diff-45033f0af51b02f3d77fd715382eaad0941e66d2655be1a80ad2cbe521ff17eeL129-L137) [[6]](diffhunk://#diff-45033f0af51b02f3d77fd715382eaad0941e66d2655be1a80ad2cbe521ff17eeL146-L154) [[7]](diffhunk://#diff-bf420b8616c7b88e5009f345a41e9723f1d8cec27c0d91bff54c260a5388b8c2L31-L61) [[8]](diffhunk://#diff-34fba16aa6b189cc8f0ce5499e2576dfb2ceb5c509511ccf85be25e2be7cfc6aL44-L51) [[9]](diffhunk://#diff-34fba16aa6b189cc8f0ce5499e2576dfb2ceb5c509511ccf85be25e2be7cfc6aL64-L71) [[10]](diffhunk://#diff-34fba16aa6b189cc8f0ce5499e2576dfb2ceb5c509511ccf85be25e2be7cfc6aL84-L91) [[11]](diffhunk://#diff-34fba16aa6b189cc8f0ce5499e2576dfb2ceb5c509511ccf85be25e2be7cfc6aL104-L112) [[12]](diffhunk://#diff-34fba16aa6b189cc8f0ce5499e2576dfb2ceb5c509511ccf85be25e2be7cfc6aL126-L134) [[13]](diffhunk://#diff-34fba16aa6b189cc8f0ce5499e2576dfb2ceb5c509511ccf85be25e2be7cfc6aL150-L158) [[14]](diffhunk://#diff-34fba16aa6b189cc8f0ce5499e2576dfb2ceb5c509511ccf85be25e2be7cfc6aL168-L176) [[15]](diffhunk://#diff-34fba16aa6b189cc8f0ce5499e2576dfb2ceb5c509511ccf85be25e2be7cfc6aL186-L210) [[16]](diffhunk://#diff-34fba16aa6b189cc8f0ce5499e2576dfb2ceb5c509511ccf85be25e2be7cfc6aL219-L227) [[17]](diffhunk://#diff-287c670de11cf3b0c605bfebedc81a3399ddb3c1968509c2310c2f02f8feac17L31-L94) [[18]](diffhunk://#diff-d4c016e1b4a8c376dc2aa8432e9d1371c70a103b4ac5951cf66e664fb934a75bL42-L49) [[19]](diffhunk://#diff-d4c016e1b4a8c376dc2aa8432e9d1371c70a103b4ac5951cf66e664fb934a75bL61-L68) [[20]](diffhunk://#diff-d4c016e1b4a8c376dc2aa8432e9d1371c70a103b4ac5951cf66e664fb934a75bL80-L88) [[21]](diffhunk://#diff-d4c016e1b4a8c376dc2aa8432e9d1371c70a103b4ac5951cf66e664fb934a75bL97-L105)
* Imports of `json_extra_fields_policy` were removed from files that no longer require it, further streamlining the code. [[1]](diffhunk://#diff-34fba16aa6b189cc8f0ce5499e2576dfb2ceb5c509511ccf85be25e2be7cfc6aL31-R31) [[2]](diffhunk://#diff-d4c016e1b4a8c376dc2aa8432e9d1371c70a103b4ac5951cf66e664fb934a75bL31-R31) [[3]](diffhunk://#diff-287c670de11cf3b0c605bfebedc81a3399ddb3c1968509c2310c2f02f8feac17L31-L94) [[4]](diffhunk://#diff-bf420b8616c7b88e5009f345a41e9723f1d8cec27c0d91bff54c260a5388b8c2L31-L61)

**DTO model updates:**

* The use of `json_extra_fields_policy` in the `Config` of DTO models such as `StatsResponseDto` and `CreateMcpServerDto` was removed, following the new centralized approach. [[1]](diffhunk://#diff-830dd5f324fa5cd9e2178902882cd625a672f2d9ee2f894e9b3b2bab37fca663L100-L104) [[2]](diffhunk://#diff-830dd5f324fa5cd9e2178902882cd625a672f2d9ee2f894e9b3b2bab37fca663L164-L171)
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.

**Special notes for your reviewer**:
