### PR TITLE
feat: add application installation and shell command features

### DIFF
--- a/docs/example.md
+++ b/docs/example.md
@@ -1613,6 +1613,118 @@ with LybicSyncClient(
     print("APK installation started")
 ```
 
+#### 3. Install Sandbox Application (Since 1.4)
+
+Request installation of an application on a sandbox through the lybic service. Returns an operation ID that can be used to track the installation progress.
+
+method: `install_sandbox_application(sandbox_id: str, app_id: str)`
+- args:
+  - sandbox_id: str ID of the sandbox
+  - app_id: str ID of the application to install
+- return: `SandboxApplicationInstallAcceptedDto` containing `operationId` and initial `status`
+
+```python
+import asyncio
+from lybic import LybicClient, LybicAuth
+
+async def install_sandbox_app_example():
+    async with LybicClient(
+        LybicAuth(
+            org_id="ORG-xxxx",
+            api_key="lysk-xxxxxxxxxxx",
+            endpoint="https://api.lybic.cn/"
+        )
+    ) as client:
+        result = await client.tools.mobile_use.install_sandbox_application(
+            sandbox_id="SBX-xxxx",
+            app_id="APP-xxxx"
+        )
+        print(f"Operation ID: {result.operationId}")
+        print(f"Initial status: {result.status}")
+
+if __name__ == '__main__':
+    asyncio.run(install_sandbox_app_example())
+```
+
+#### 4. Get Sandbox Application Operation
+
+Query the latest state of an application installation operation.
+
+method: `get_sandbox_application_operation(sandbox_id: str, operation_id: str)`
+- args:
+  - sandbox_id: str ID of the sandbox
+  - operation_id: str ID of the sandbox operation (returned by `install_sandbox_application`)
+- return: `SandboxApplicationOperationDto` containing `status` and `detail`
+
+**Operation Status Values:** `PENDING`, `RUNNING`, `SUCCEEDED`, `FAILED`, `CANCELLED`
+
+```python
+import asyncio
+import time
+from lybic import LybicClient, LybicAuth
+
+async def poll_install_operation_example():
+    async with LybicClient(
+        LybicAuth(
+            org_id="ORG-xxxx",
+            api_key="lysk-xxxxxxxxxxx",
+            endpoint="https://api.lybic.cn/"
+        )
+    ) as client:
+        # Start installation
+        accepted = await client.tools.mobile_use.install_sandbox_application(
+            sandbox_id="SBX-xxxx",
+            app_id="APP-xxxx"
+        )
+        print(f"Installation started, operation ID: {accepted.operationId}")
+
+        # Poll until the operation completes
+        while True:
+            operation = await client.tools.mobile_use.get_sandbox_application_operation(
+                sandbox_id="SBX-xxxx",
+                operation_id=accepted.operationId
+            )
+            print(f"Status: {operation.status}")
+            if operation.status in ("SUCCEEDED", "FAILED", "CANCELLED"):
+                print(f"Final status: {operation.status}, detail: {operation.detail}")
+                break
+            await asyncio.sleep(5)
+
+if __name__ == '__main__':
+    asyncio.run(poll_install_operation_example())
+```
+
+**Synchronous Usage:**
+
+```python
+import time
+from lybic_sync import LybicSyncClient, LybicAuth
+
+with LybicSyncClient(
+    LybicAuth(
+        org_id="ORG-xxxx",
+        api_key="lysk-xxxxxxxxxxx",
+        endpoint="https://api.lybic.cn/"
+    )
+) as client:
+    accepted = client.tools.mobile_use.install_sandbox_application(
+        sandbox_id="SBX-xxxx",
+        app_id="APP-xxxx"
+    )
+    print(f"Operation ID: {accepted.operationId}")
+
+    while True:
+        operation = client.tools.mobile_use.get_sandbox_application_operation(
+            sandbox_id="SBX-xxxx",
+            operation_id=accepted.operationId
+        )
+        print(f"Status: {operation.status}")
+        if operation.status in ("SUCCEEDED", "FAILED", "CANCELLED"):
+            print(f"Final status: {operation.status}, detail: {operation.detail}")
+            break
+        time.sleep(5)
+```
+
 ### Error Handling
 
 The SDK provides user-friendly exceptions for API errors instead of raw HTTP errors.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -362,6 +362,284 @@
         ]
       }
     },
+    "/api/orgs/{orgId}/sandboxes/{sandboxId}/shell/stream": {
+      "post": {
+        "operationId": "createSandboxShellCommand",
+        "parameters": [
+          {
+            "name": "sandboxId",
+            "required": true,
+            "in": "path",
+            "description": "The sandbox ID",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "orgId",
+            "required": true,
+            "in": "path",
+            "description": "The organization ID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SandboxShellCommandStreamCreateRequestDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "summary": "Create Sandbox Shell (SSE)",
+        "tags": [
+          "Sandbox"
+        ]
+      }
+    },
+    "/api/orgs/{orgId}/sandboxes/{sandboxId}/shell": {
+      "post": {
+        "operationId": "createSandboxShellCommand",
+        "parameters": [
+          {
+            "name": "sandboxId",
+            "required": true,
+            "in": "path",
+            "description": "The sandbox ID",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "orgId",
+            "required": true,
+            "in": "path",
+            "description": "The organization ID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SandboxShellCommandCreateRequestDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SandboxShellCommandCreateResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Create Sandbox Shell",
+        "tags": [
+          "Sandbox"
+        ]
+      }
+    },
+    "/api/orgs/{orgId}/sandboxes/{sandboxId}/shell/{shellId}": {
+      "post": {
+        "operationId": "writeSandboxShellCommand",
+        "parameters": [
+          {
+            "name": "sandboxId",
+            "required": true,
+            "in": "path",
+            "description": "The sandbox ID",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "shellId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "orgId",
+            "required": true,
+            "in": "path",
+            "description": "The organization ID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SandboxShellCommandWriteRequestDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "summary": "Write Text to Sandbox Shell",
+        "tags": [
+          "Sandbox"
+        ]
+      },
+      "delete": {
+        "operationId": "terminateSandboxShellCommand",
+        "parameters": [
+          {
+            "name": "sandboxId",
+            "required": true,
+            "in": "path",
+            "description": "The sandbox ID",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "shellId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "orgId",
+            "required": true,
+            "in": "path",
+            "description": "The organization ID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "summary": "Terminate Sandbox Shell",
+        "tags": [
+          "Sandbox"
+        ]
+      }
+    },
+    "/api/orgs/{orgId}/sandboxes/{sandboxId}/shell/{shellId}/finish": {
+      "put": {
+        "operationId": "finishSandboxShellCommand",
+        "parameters": [
+          {
+            "name": "sandboxId",
+            "required": true,
+            "in": "path",
+            "description": "The sandbox ID",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "shellId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "orgId",
+            "required": true,
+            "in": "path",
+            "description": "The organization ID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "summary": "Finish Writing to Sandbox Shell",
+        "tags": [
+          "Sandbox"
+        ]
+      }
+    },
+    "/api/orgs/{orgId}/sandboxes/{sandboxId}/shell/{shellId}/read": {
+      "post": {
+        "operationId": "readSandboxShellCommand",
+        "parameters": [
+          {
+            "name": "sandboxId",
+            "required": true,
+            "in": "path",
+            "description": "The sandbox ID",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "shellId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "orgId",
+            "required": true,
+            "in": "path",
+            "description": "The organization ID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SandboxShellCommandReadResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Read Sandbox Shell Output",
+        "tags": [
+          "Sandbox"
+        ]
+      }
+    },
     "/api/orgs/{orgId}/sandboxes/from-image": {
       "post": {
         "description": "Creates a new sandbox from a machine image.",
@@ -723,6 +1001,16 @@
             }
           }
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SandboxPreviewRequestDto"
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "",
@@ -736,6 +1024,108 @@
           }
         },
         "summary": "Preview Sandbox",
+        "tags": [
+          "Sandbox"
+        ]
+      }
+    },
+    "/api/orgs/{orgId}/sandboxes/{sandboxId}/apps/{appId}": {
+      "put": {
+        "description": "Requests application installations on a sandbox through nomos.",
+        "operationId": "installSandboxApplication",
+        "parameters": [
+          {
+            "name": "sandboxId",
+            "required": true,
+            "in": "path",
+            "description": "The sandbox ID",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "appId",
+            "required": true,
+            "in": "path",
+            "description": "The app ID",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "orgId",
+            "required": true,
+            "in": "path",
+            "description": "The organization ID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SandboxApplicationInstallAcceptedDto"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Install Sandbox Application",
+        "tags": [
+          "Sandbox"
+        ]
+      }
+    },
+    "/api/orgs/{orgId}/sandboxes/{sandboxId}/operations/{operationId}": {
+      "get": {
+        "description": "Returns the latest state of an application installation operation.",
+        "operationId": "getSandboxApplicationOperation",
+        "parameters": [
+          {
+            "name": "sandboxId",
+            "required": true,
+            "in": "path",
+            "description": "The sandbox ID",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "operationId",
+            "required": true,
+            "in": "path",
+            "description": "The sandbox operation ID",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "orgId",
+            "required": true,
+            "in": "path",
+            "description": "The organization ID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SandboxApplicationOperationDto"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Get Sandbox Application Operation",
         "tags": [
           "Sandbox"
         ]
@@ -2047,6 +2437,192 @@
         },
         "required": [
           "exitCode"
+        ]
+      },
+      "SandboxShellCommandStreamCreateRequestDto": {
+        "type": "object",
+        "properties": {
+          "command": {
+            "description": "The command to execute in the shell.",
+            "type": "string",
+            "minLength": 1
+          },
+          "useTty": {
+            "description": "Whether to use a TTY for the shell session.",
+            "type": "boolean",
+            "default": false
+          },
+          "timeoutSeconds": {
+            "description": "Optional timeout for the shell session in seconds.",
+            "type": "number",
+            "minimum": 1,
+            "exclusiveMinimum": false,
+            "maximum": 86400,
+            "exclusiveMaximum": false
+          },
+          "workingDirectory": {
+            "description": "Optional working directory for the shell session.",
+            "type": "string"
+          },
+          "ttyRows": {
+            "description": "Number of rows for TTY (if useTty is true).",
+            "type": "number",
+            "minimum": 1,
+            "exclusiveMinimum": false
+          },
+          "ttyCols": {
+            "description": "Number of columns for TTY (if useTty is true).",
+            "type": "number",
+            "minimum": 1,
+            "exclusiveMinimum": false
+          }
+        },
+        "required": [
+          "command"
+        ]
+      },
+      "SandboxShellCommandCreateRequestDto": {
+        "type": "object",
+        "properties": {
+          "command": {
+            "description": "The command to execute in the shell.",
+            "type": "string",
+            "minLength": 1
+          },
+          "useTty": {
+            "description": "Whether to use a TTY for the shell session.",
+            "type": "boolean",
+            "default": false
+          },
+          "timeoutSeconds": {
+            "description": "Optional timeout for the shell session in seconds.",
+            "type": "number",
+            "minimum": 1,
+            "exclusiveMinimum": false,
+            "maximum": 86400,
+            "exclusiveMaximum": false
+          },
+          "workingDirectory": {
+            "description": "Optional working directory for the shell session.",
+            "type": "string"
+          },
+          "ttyRows": {
+            "description": "Number of rows for TTY (if useTty is true).",
+            "type": "number",
+            "minimum": 1,
+            "exclusiveMinimum": false
+          },
+          "ttyCols": {
+            "description": "Number of columns for TTY (if useTty is true).",
+            "type": "number",
+            "minimum": 1,
+            "exclusiveMinimum": false
+          }
+        },
+        "required": [
+          "command"
+        ]
+      },
+      "SandboxShellCommandCreateResponseDto": {
+        "type": "object",
+        "properties": {
+          "sessionId": {
+            "description": "The ID of the created shell session.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "sessionId"
+        ]
+      },
+      "SandboxShellCommandWriteRequestDto": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "description": "The input data to write to the shell session.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "SandboxShellCommandReadResponseDto": {
+        "type": "object",
+        "properties": {
+          "output": {
+            "description": "Accumulated output parts from the shell session.",
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "oneofKind": {
+                      "type": "string",
+                      "enum": [
+                        "stdout"
+                      ]
+                    },
+                    "stdout": {
+                      "description": "Standard output from the shell session.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "oneofKind",
+                    "stdout"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "oneofKind": {
+                      "type": "string",
+                      "enum": [
+                        "stderr"
+                      ]
+                    },
+                    "stderr": {
+                      "description": "Standard error output from the shell session.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "oneofKind",
+                    "stderr"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "oneofKind": {
+                      "type": "string",
+                      "enum": [
+                        "waiting"
+                      ]
+                    },
+                    "waiting": {
+                      "description": "Indicates a prompt waiting state.",
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "oneofKind",
+                    "waiting"
+                  ]
+                }
+              ]
+            }
+          },
+          "isRunning": {
+            "description": "Whether the shell session is still running.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "output",
+          "isRunning"
         ]
       },
       "CreateSandboxFromImageDto": {
@@ -3468,6 +4044,11 @@
                 "type": "string"
               }
             }
+          },
+          "screenShotPutUrl": {
+            "description": "Optional screenshot upload URL, if provided, the screenshot will be uploaded to this URL using HTTP PUT method",
+            "type": "string",
+            "format": "uri"
           },
           "includeScreenShot": {
             "description": "Whether to include the screenshot url after action in the response",
@@ -5391,6 +5972,11 @@
               }
             ]
           },
+          "screenShotPutUrl": {
+            "description": "Optional screenshot upload URL, passed through to redshift for BYO storage.",
+            "type": "string",
+            "format": "uri"
+          },
           "includeScreenShot": {
             "description": "Whether to include the screenshot url after action in the response",
             "type": "boolean",
@@ -5404,6 +5990,60 @@
         },
         "required": [
           "action"
+        ]
+      },
+      "SandboxPreviewRequestDto": {
+        "type": "object",
+        "properties": {
+          "screenShotPutUrl": {
+            "description": "Optional screenshot upload URL, passed through to redshift for BYO storage.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      },
+      "SandboxApplicationInstallAcceptedDto": {
+        "type": "object",
+        "properties": {
+          "operationId": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "PENDING",
+              "RUNNING",
+              "SUCCEEDED",
+              "FAILED",
+              "CANCELLED"
+            ]
+          }
+        },
+        "required": [
+          "operationId",
+          "status"
+        ]
+      },
+      "SandboxApplicationOperationDto": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "PENDING",
+              "RUNNING",
+              "SUCCEEDED",
+              "FAILED",
+              "CANCELLED"
+            ]
+          },
+          "detail": {
+            "nullable": true
+          }
+        },
+        "required": [
+          "status",
+          "detail"
         ]
       },
       "HttpMappingListResponseDto": {

--- a/lybic/dto.py
+++ b/lybic/dto.py
@@ -618,6 +618,24 @@ class HttpRemote(BaseModel):
 
 APPSources = AndroidLocal | HttpRemote
 
+SandboxApplicationStatus = Literal["PENDING", "RUNNING", "SUCCEEDED", "FAILED", "CANCELLED"]
+
+class SandboxApplicationInstallAcceptedDto(BaseModel):
+    """
+    Response from install sandbox application request.
+    """
+    operationId: str = Field(..., description="The ID of the installation operation.")
+    status: SandboxApplicationStatus = Field(..., description="Current status of the operation.")
+
+
+class SandboxApplicationOperationDto(BaseModel):
+    """
+    Latest state of an application installation operation.
+    """
+    status: SandboxApplicationStatus = Field(..., description="Current status of the operation.")
+    detail: Optional[Any] = Field(..., description="Additional detail about the operation result.")
+
+
 class CreateHttpMappingDto(BaseModel):
     """
     Create HTTP mapping request.

--- a/lybic/tools.py
+++ b/lybic/tools.py
@@ -38,7 +38,9 @@ from lybic.dto import (
     MobileUseActionResponseDto,
     APPSources,
     AndroidLocal,
-    HttpRemote
+    HttpRemote,
+    SandboxApplicationInstallAcceptedDto,
+    SandboxApplicationOperationDto,
 )
 
 if TYPE_CHECKING:
@@ -201,6 +203,44 @@ class MobileUse:
             executable="sh",
             args=["-c", f"nohup sh -c '{script_content}' >/dev/null 2>&1 &"],
         )
+
+    async def install_sandbox_application(
+        self, sandbox_id: str, app_id: str
+    ) -> SandboxApplicationInstallAcceptedDto:
+        """Request application installation on a sandbox through nomos.
+
+        Args:
+            sandbox_id: The ID of the sandbox.
+            app_id: The ID of the application to install.
+
+        Returns:
+            A DTO containing the operation ID and initial status.
+        """
+        response = await self.client.request(
+            "PUT",
+            f"/api/orgs/{self.client.org_id}/sandboxes/{sandbox_id}/apps/{app_id}",
+        )
+        self.client.logger.debug(f"Install sandbox application response: {response.text}")
+        return SandboxApplicationInstallAcceptedDto.model_validate_json(response.text)
+
+    async def get_sandbox_application_operation(
+        self, sandbox_id: str, operation_id: str
+    ) -> SandboxApplicationOperationDto:
+        """Get the latest state of an application installation operation.
+
+        Args:
+            sandbox_id: The ID of the sandbox.
+            operation_id: The ID of the sandbox operation.
+
+        Returns:
+            A DTO containing the current status and detail of the operation.
+        """
+        response = await self.client.request(
+            "GET",
+            f"/api/orgs/{self.client.org_id}/sandboxes/{sandbox_id}/operations/{operation_id}",
+        )
+        self.client.logger.debug(f"Get sandbox application operation response: {response.text}")
+        return SandboxApplicationOperationDto.model_validate_json(response.text)
 
 class Tools:
     """Tools is a container for various tool clients."""

--- a/lybic_sync/tools.py
+++ b/lybic_sync/tools.py
@@ -38,7 +38,9 @@ from lybic.dto import (
     MobileUseActionResponseDto,
     APPSources,
     AndroidLocal,
-    HttpRemote
+    HttpRemote,
+    SandboxApplicationInstallAcceptedDto,
+    SandboxApplicationOperationDto,
 )
 
 if TYPE_CHECKING:
@@ -202,6 +204,44 @@ class MobileUseSync:
             executable="sh",
             args=["-c", f"nohup sh -c '{script_content}' >/dev/null 2>&1 &"],
         )
+
+    def install_sandbox_application(
+        self, sandbox_id: str, app_id: str
+    ) -> SandboxApplicationInstallAcceptedDto:
+        """Request application installation on a sandbox through nomos.
+
+        Args:
+            sandbox_id: The ID of the sandbox.
+            app_id: The ID of the application to install.
+
+        Returns:
+            A DTO containing the operation ID and initial status.
+        """
+        response = self.client.request(
+            "PUT",
+            f"/api/orgs/{self.client.org_id}/sandboxes/{sandbox_id}/apps/{app_id}",
+        )
+        self.client.logger.debug(f"Install sandbox application response: {response.text}")
+        return SandboxApplicationInstallAcceptedDto.model_validate_json(response.text)
+
+    def get_sandbox_application_operation(
+        self, sandbox_id: str, operation_id: str
+    ) -> SandboxApplicationOperationDto:
+        """Get the latest state of an application installation operation.
+
+        Args:
+            sandbox_id: The ID of the sandbox.
+            operation_id: The ID of the sandbox operation.
+
+        Returns:
+            A DTO containing the current status and detail of the operation.
+        """
+        response = self.client.request(
+            "GET",
+            f"/api/orgs/{self.client.org_id}/sandboxes/{sandbox_id}/operations/{operation_id}",
+        )
+        self.client.logger.debug(f"Get sandbox application operation response: {response.text}")
+        return SandboxApplicationOperationDto.model_validate_json(response.text)
 
 class ToolsSync:
     """ToolsSync is a container for various synchronous tool clients."""


### PR DESCRIPTION
#### What this PR does / why we need it? Summary of your change
- Add SandboxApplicationInstallAcceptedDto and SandboxApplicationOperationDto models
- Implement install_sandbox_application method to request app installation on sandbox
- Implement get_sandbox_application_operation method to query installation status
- Add sandbox shell command endpoints including create, write, read, and terminate
- Update OpenAPI specification with new sandbox application and shell operations
- Add documentation for sandbox application installation and polling examples
- Include SandboxApplicationStatus literal type with PENDING, RUNNING, SUCCEEDED, FAILED, CANCELLED values


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.

**Special notes for your reviewer**:
